### PR TITLE
fix: Claude Code 실행 플래그를 --print에서 --prompt로 변경

### DIFF
--- a/.github/scripts/respond_to_review/clients.py
+++ b/.github/scripts/respond_to_review/clients.py
@@ -185,7 +185,7 @@ class ClaudeClientImpl(ClaudeClient):
     def run(self, prompt: str) -> str:
         logger.info("Running Claude Code...")
         result = subprocess.run(
-            ["claude", "--dangerously-skip-permissions", "--print", prompt],
+            ["claude", "--dangerously-skip-permissions", "--prompt", prompt],
             capture_output=True,
             text=True,
         )


### PR DESCRIPTION
## Summary
- Claude Code 실행 시 `--print` 플래그를 `--prompt`로 변경
- `--print`는 텍스트 출력만 하고 도구(Edit, Write, Bash)를 실행하지 않음
- `--prompt`로 변경하여 실제 파일 수정 및 git commit/push가 가능하도록 함

## Test plan
- [ ] GHA Runner에서 Claude Code가 실제로 파일을 수정하는지 확인
- [ ] 수정 후 git commit/push가 정상 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)