### PR TITLE
fix: stream-json 출력에 --verbose 플래그 추가

### DIFF
--- a/.github/scripts/respond_to_review/clients.py
+++ b/.github/scripts/respond_to_review/clients.py
@@ -194,9 +194,10 @@ class ClaudeClientImpl(ClaudeClient):
             "-p",
             "--dangerously-skip-permissions",
             "--output-format", "stream-json",
+            "--verbose",
             prompt,
         ]
-        logger.debug("Command: claude -p --dangerously-skip-permissions --output-format stream-json <prompt>")
+        logger.debug("Command: claude -p --dangerously-skip-permissions --output-format stream-json --verbose <prompt>")
 
         result = subprocess.run(
             cmd,


### PR DESCRIPTION
## Summary
`--output-format stream-json`을 `--print`와 함께 사용할 때 `--verbose` 플래그 필수

## 에러
```
Error: When using --print, --output-format=stream-json requires --verbose
```

## 수정
```python
cmd = [
    "claude",
    "-p",
    "--dangerously-skip-permissions",
    "--output-format", "stream-json",
    "--verbose",  # 추가
    prompt,
]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)