### PR TITLE
fix: --allowedTools 플래그 추가하여 도구 실행 활성화

### DIFF
--- a/.github/scripts/respond_to_review/clients.py
+++ b/.github/scripts/respond_to_review/clients.py
@@ -193,11 +193,12 @@ class ClaudeClientImpl(ClaudeClient):
             "claude",
             "-p",
             "--dangerously-skip-permissions",
+            "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep",
             "--output-format", "stream-json",
             "--verbose",
             prompt,
         ]
-        logger.debug("Command: claude -p --dangerously-skip-permissions --output-format stream-json --verbose <prompt>")
+        logger.debug("Command: claude -p --dangerously-skip-permissions --allowedTools Edit,Write,Bash,Read,Glob,Grep --output-format stream-json --verbose <prompt>")
 
         result = subprocess.run(
             cmd,


### PR DESCRIPTION
## Summary
`--dangerously-skip-permissions`만으로는 도구가 실행되지 않아 `--allowedTools` 플래그 추가

## 문제
- Claude가 "수정했습니다"라고 응답하지만 실제 파일 변경 없음
- stream-json 이벤트에 `tool_use`, `tool_result` 이벤트 없음

## 수정
```python
cmd = [
    "claude",
    "-p",
    "--dangerously-skip-permissions",
    "--allowedTools", "Edit,Write,Bash,Read,Glob,Grep",  # 추가
    "--output-format", "stream-json",
    "--verbose",
    prompt,
]
```

## 참고
[공식 문서 예제](https://code.claude.com/docs/en/headless):
```bash
claude -p "Run the test suite and fix any failures" --allowedTools "Bash,Read,Edit"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)