### PR TITLE
fix: Confluence CLI 마크다운 변환 버그 수정

### DIFF
--- a/bin/confluence
+++ b/bin/confluence
@@ -23,78 +23,11 @@ api_call() {
 }
 
 api_post() {
-  curl -s --user "$CREDS" -X POST -H "Content-Type: application/json" -d "$2" "${BASE_URL}$1"
+  curl -s --user "$CREDS" -X POST -H "Content-Type: application/json" -d @- "${BASE_URL}$1"
 }
 
 api_put() {
-  curl -s --user "$CREDS" -X PUT -H "Content-Type: application/json" -d "$2" "${BASE_URL}$1"
-}
-
-markdown_to_confluence() {
-  # Convert markdown to Confluence storage format (XHTML)
-  python3 << 'PYEOF'
-import sys
-import re
-
-content = sys.stdin.read()
-
-# Headers
-content = re.sub(r'^###### (.+)$', r'<h6>\1</h6>', content, flags=re.MULTILINE)
-content = re.sub(r'^##### (.+)$', r'<h5>\1</h5>', content, flags=re.MULTILINE)
-content = re.sub(r'^#### (.+)$', r'<h4>\1</h4>', content, flags=re.MULTILINE)
-content = re.sub(r'^### (.+)$', r'<h3>\1</h3>', content, flags=re.MULTILINE)
-content = re.sub(r'^## (.+)$', r'<h2>\1</h2>', content, flags=re.MULTILINE)
-content = re.sub(r'^# (.+)$', r'<h1>\1</h1>', content, flags=re.MULTILINE)
-
-# Bold and italic
-content = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', content)
-content = re.sub(r'\*(.+?)\*', r'<em>\1</em>', content)
-
-# Horizontal rule
-content = re.sub(r'^---+$', r'<hr/>', content, flags=re.MULTILINE)
-
-# Simple table conversion
-lines = content.split('\n')
-result = []
-in_table = False
-table_rows = []
-
-for line in lines:
-    if '|' in line and line.strip().startswith('|'):
-        if not in_table:
-            in_table = True
-            table_rows = []
-        # Skip separator lines
-        if re.match(r'^\|[\s\-:|]+\|$', line.strip()):
-            continue
-        cells = [c.strip() for c in line.strip().split('|')[1:-1]]
-        table_rows.append(cells)
-    else:
-        if in_table:
-            # Output table
-            result.append('<table><tbody>')
-            for i, row in enumerate(table_rows):
-                tag = 'th' if i == 0 else 'td'
-                result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
-            result.append('</tbody></table>')
-            in_table = False
-            table_rows = []
-        result.append(line)
-
-if in_table:
-    result.append('<table><tbody>')
-    for i, row in enumerate(table_rows):
-        tag = 'th' if i == 0 else 'td'
-        result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
-    result.append('</tbody></table>')
-
-content = '\n'.join(result)
-
-# Convert newlines to <br/> for non-block elements
-content = re.sub(r'(?<!</h[1-6]>)(?<!</table>)(?<!</tr>)(?<!</tbody>)(?<!</p>)(?<!</hr>)\n(?!<)', '<br/>\n', content)
-
-print(content)
-PYEOF
+  curl -s --user "$CREDS" -X PUT -H "Content-Type: application/json" -d @- "${BASE_URL}$1"
 }
 
 cmd="${1:-help}"
@@ -169,7 +102,7 @@ elif [[ "$cmd" == "create" ]]; then
   parent_id="${3:-}"
   title="${4:-}"
   md_file="${5:-}"
-  
+
   if [[ -z "$space_key" || -z "$parent_id" || -z "$title" || -z "$md_file" ]]; then
     echo "Usage: confluence create <spaceKey> <parentId> <title> <markdown_file>"
     echo ""
@@ -177,39 +110,98 @@ elif [[ "$cmd" == "create" ]]; then
     echo "  confluence create ~712020xxx 506822712 'My Page Title' ./report.md"
     exit 1
   fi
-  
+
   if [[ ! -f "$md_file" ]]; then
     echo "Error: File not found: $md_file"
     exit 1
   fi
-  
-  # Convert markdown to Confluence format
-  body_content=$(cat "$md_file" | markdown_to_confluence)
-  
-  # Escape for JSON
-  escaped_body=$(echo "$body_content" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
-  escaped_title=$(echo "$title" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")
-  
-  json_payload=$(cat << JSONEOF
-{
-  "type": "page",
-  "title": ${escaped_title},
-  "space": {"key": "${space_key}"},
-  "ancestors": [{"id": "${parent_id}"}],
-  "body": {
-    "storage": {
-      "value": ${escaped_body},
-      "representation": "storage"
+
+  # Convert markdown to Confluence format and create JSON payload
+  python3 -c "
+import sys
+import re
+import json
+
+with open('$md_file', 'r') as f:
+    content = f.read()
+
+# Headers
+content = re.sub(r'^###### (.+)$', r'<h6>\1</h6>', content, flags=re.MULTILINE)
+content = re.sub(r'^##### (.+)$', r'<h5>\1</h5>', content, flags=re.MULTILINE)
+content = re.sub(r'^#### (.+)$', r'<h4>\1</h4>', content, flags=re.MULTILINE)
+content = re.sub(r'^### (.+)$', r'<h3>\1</h3>', content, flags=re.MULTILINE)
+content = re.sub(r'^## (.+)$', r'<h2>\1</h2>', content, flags=re.MULTILINE)
+content = re.sub(r'^# (.+)$', r'<h1>\1</h1>', content, flags=re.MULTILINE)
+
+# Bold and italic
+content = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', content)
+content = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<em>\1</em>', content)
+
+# Horizontal rule
+content = re.sub(r'^---+$', r'<hr/>', content, flags=re.MULTILINE)
+
+# Simple table conversion
+lines = content.split('\n')
+result = []
+in_table = False
+table_rows = []
+
+for line in lines:
+    if '|' in line and line.strip().startswith('|'):
+        if not in_table:
+            in_table = True
+            table_rows = []
+        # Skip separator lines
+        if re.match(r'^\|[\s\-:|]+\|$', line.strip()):
+            continue
+        cells = [c.strip() for c in line.strip().split('|')[1:-1]]
+        table_rows.append(cells)
+    else:
+        if in_table:
+            # Output table
+            result.append('<table><tbody>')
+            for i, row in enumerate(table_rows):
+                tag = 'th' if i == 0 else 'td'
+                result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
+            result.append('</tbody></table>')
+            in_table = False
+            table_rows = []
+        result.append(line)
+
+if in_table:
+    result.append('<table><tbody>')
+    for i, row in enumerate(table_rows):
+        tag = 'th' if i == 0 else 'td'
+        result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
+    result.append('</tbody></table>')
+
+content = '\n'.join(result)
+
+# Paragraphs - wrap non-tag lines
+final_lines = []
+for line in content.split('\n'):
+    stripped = line.strip()
+    if stripped and not stripped.startswith('<') and not stripped.endswith('>'):
+        final_lines.append(f'<p>{line}</p>')
+    else:
+        final_lines.append(line)
+content = '\n'.join(final_lines)
+
+payload = {
+    'type': 'page',
+    'title': '$title',
+    'space': {'key': '$space_key'},
+    'ancestors': [{'id': '$parent_id'}],
+    'body': {
+        'storage': {
+            'value': content,
+            'representation': 'storage'
+        }
     }
-  }
 }
-JSONEOF
-)
-  
-  result=$(api_post "/rest/api/content" "$json_payload")
-  
-  # Check result
-  echo "$result" | python3 -c "
+
+print(json.dumps(payload))
+" | api_post "/rest/api/content" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 if 'id' in data:
@@ -229,48 +221,108 @@ elif [[ "$cmd" == "update" ]]; then
   # Usage: confluence update <pageId> <markdown_file>
   page_id="${2:-}"
   md_file="${3:-}"
-  
+
   if [[ -z "$page_id" || -z "$md_file" ]]; then
     echo "Usage: confluence update <pageId> <markdown_file>"
     exit 1
   fi
-  
+
   if [[ ! -f "$md_file" ]]; then
     echo "Error: File not found: $md_file"
     exit 1
   fi
-  
+
   # Get current page info (for version number and title)
   page_info=$(api_call "/rest/api/content/${page_id}?expand=version")
   current_version=$(echo "$page_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('version',{}).get('number',1))")
   current_title=$(echo "$page_info" | python3 -c "import sys,json; print(json.load(sys.stdin).get('title',''))")
   new_version=$((current_version + 1))
-  
-  # Convert markdown to Confluence format
-  body_content=$(cat "$md_file" | markdown_to_confluence)
-  
-  # Escape for JSON
-  escaped_body=$(echo "$body_content" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read()))")
-  escaped_title=$(echo "$current_title" | python3 -c "import sys,json; print(json.dumps(sys.stdin.read().strip()))")
-  
-  json_payload=$(cat << JSONEOF
-{
-  "type": "page",
-  "title": ${escaped_title},
-  "version": {"number": ${new_version}},
-  "body": {
-    "storage": {
-      "value": ${escaped_body},
-      "representation": "storage"
+
+  # Convert markdown to Confluence format and create JSON payload
+  python3 -c "
+import sys
+import re
+import json
+
+with open('$md_file', 'r') as f:
+    content = f.read()
+
+# Headers
+content = re.sub(r'^###### (.+)$', r'<h6>\1</h6>', content, flags=re.MULTILINE)
+content = re.sub(r'^##### (.+)$', r'<h5>\1</h5>', content, flags=re.MULTILINE)
+content = re.sub(r'^#### (.+)$', r'<h4>\1</h4>', content, flags=re.MULTILINE)
+content = re.sub(r'^### (.+)$', r'<h3>\1</h3>', content, flags=re.MULTILINE)
+content = re.sub(r'^## (.+)$', r'<h2>\1</h2>', content, flags=re.MULTILINE)
+content = re.sub(r'^# (.+)$', r'<h1>\1</h1>', content, flags=re.MULTILINE)
+
+# Bold and italic
+content = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', content)
+content = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<em>\1</em>', content)
+
+# Horizontal rule
+content = re.sub(r'^---+$', r'<hr/>', content, flags=re.MULTILINE)
+
+# Simple table conversion
+lines = content.split('\n')
+result = []
+in_table = False
+table_rows = []
+
+for line in lines:
+    if '|' in line and line.strip().startswith('|'):
+        if not in_table:
+            in_table = True
+            table_rows = []
+        # Skip separator lines
+        if re.match(r'^\|[\s\-:|]+\|$', line.strip()):
+            continue
+        cells = [c.strip() for c in line.strip().split('|')[1:-1]]
+        table_rows.append(cells)
+    else:
+        if in_table:
+            # Output table
+            result.append('<table><tbody>')
+            for i, row in enumerate(table_rows):
+                tag = 'th' if i == 0 else 'td'
+                result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
+            result.append('</tbody></table>')
+            in_table = False
+            table_rows = []
+        result.append(line)
+
+if in_table:
+    result.append('<table><tbody>')
+    for i, row in enumerate(table_rows):
+        tag = 'th' if i == 0 else 'td'
+        result.append('<tr>' + ''.join(f'<{tag}>{c}</{tag}>' for c in row) + '</tr>')
+    result.append('</tbody></table>')
+
+content = '\n'.join(result)
+
+# Paragraphs - wrap non-tag lines
+final_lines = []
+for line in content.split('\n'):
+    stripped = line.strip()
+    if stripped and not stripped.startswith('<') and not stripped.endswith('>'):
+        final_lines.append(f'<p>{line}</p>')
+    else:
+        final_lines.append(line)
+content = '\n'.join(final_lines)
+
+payload = {
+    'type': 'page',
+    'title': '''$current_title''',
+    'version': {'number': $new_version},
+    'body': {
+        'storage': {
+            'value': content,
+            'representation': 'storage'
+        }
     }
-  }
 }
-JSONEOF
-)
-  
-  result=$(api_put "/rest/api/content/${page_id}" "$json_payload")
-  
-  echo "$result" | python3 -c "
+
+print(json.dumps(payload))
+" | api_put "/rest/api/content/${page_id}" | python3 -c "
 import sys, json
 data = json.load(sys.stdin)
 if 'id' in data:
@@ -294,4 +346,7 @@ else
   echo "  page <pageId>                                   View page content"
   echo "  create <spaceKey> <parentId> <title> <mdFile>   Create child page from markdown"
   echo "  update <pageId> <mdFile>                        Update page from markdown"
+  echo ""
+  echo "Configuration:"
+  echo "  Set CONFLUENCE_CREDS=email:api_token or create ~/.config/atlassian/confluence.conf"
 fi


### PR DESCRIPTION
## Summary
- heredoc 방식의 `markdown_to_confluence` 함수에서 stdin이 heredoc으로 대체되어 마크다운 내용이 전달되지 않던 버그 수정
- inline Python으로 파일을 직접 읽도록 변경
- `api_post`/`api_put`을 stdin에서 읽도록 변경 (`-d @-`)

## Test plan
- [ ] `confluence update <pageId> <mdFile>` 명령으로 페이지 업데이트 확인
- [ ] `confluence create <spaceKey> <parentId> <title> <mdFile>` 명령으로 페이지 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)