### PR TITLE
feat: Google Analytics 및 Search Console CLI 도구 추가

### DIFF
--- a/bin/ga
+++ b/bin/ga
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""
+Google Analytics Data API 클라이언트 (GA4)
+
+사용법:
+    ga accounts                        # 계정/속성 목록
+    ga report <property_id>            # 트래픽 리포트
+    ga report <property_id> --days 30  # 최근 30일 데이터
+    ga pages <property_id>             # 페이지별 성과
+    ga sources <property_id>           # 트래픽 소스별 성과
+
+property_id 예시: 123456789 (숫자만, 'properties/' 접두사 불필요)
+
+설정:
+    1. Google Cloud Console에서 OAuth 2.0 클라이언트 ID 생성
+    2. 클라이언트 시크릿 JSON 파일 다운로드
+    3. 환경변수 설정: export GOOGLE_CLIENT_SECRET=~/.config/google/client_secret.json
+    4. 첫 실행 시 브라우저에서 OAuth 인증 수행 (토큰 자동 저장)
+"""
+
+import argparse
+import os
+import pickle
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from google.analytics.data_v1beta import BetaAnalyticsDataClient
+    from google.analytics.data_v1beta.types import (
+        RunReportRequest,
+        DateRange,
+        Dimension,
+        Metric,
+    )
+    from google.analytics.admin_v1beta import AnalyticsAdminServiceClient
+except ImportError:
+    print("필수 패키지가 설치되어 있지 않습니다. 다음 명령어로 설치하세요:")
+    print("  pip install google-auth google-auth-oauthlib google-analytics-data google-analytics-admin")
+    sys.exit(1)
+
+# API 스코프
+SCOPES = [
+    'https://www.googleapis.com/auth/analytics.readonly',
+]
+
+# 인증 파일 경로
+CLIENT_SECRET_FILE = os.environ.get(
+    'GOOGLE_CLIENT_SECRET',
+    os.path.expanduser('~/.config/google/client_secret.json')
+)
+TOKEN_FILE = os.path.expanduser('~/.config/ga/token.pickle')
+
+
+def get_credentials():
+    """OAuth 2.0 인증을 수행하고 credentials를 반환합니다."""
+    creds = None
+    token_path = Path(TOKEN_FILE)
+
+    # 클라이언트 시크릿 파일 확인
+    if not os.path.exists(CLIENT_SECRET_FILE):
+        print(f"오류: 클라이언트 시크릿 파일을 찾을 수 없습니다: {CLIENT_SECRET_FILE}")
+        print()
+        print("설정 방법:")
+        print("  1. Google Cloud Console에서 OAuth 2.0 클라이언트 ID 생성")
+        print("  2. 클라이언트 시크릿 JSON 파일 다운로드")
+        print("  3. 파일을 ~/.config/google/client_secret.json에 저장")
+        print("     또는 GOOGLE_CLIENT_SECRET 환경변수로 경로 지정")
+        sys.exit(1)
+
+    # 저장된 토큰이 있으면 로드
+    if token_path.exists():
+        with open(token_path, 'rb') as token:
+            creds = pickle.load(token)
+
+    # 토큰이 없거나 만료되었으면 새로 인증
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRET_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # 토큰 저장
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(token_path, 'wb') as token:
+            pickle.dump(creds, token)
+
+    return creds
+
+
+def list_accounts():
+    """GA4 계정 및 속성 목록을 출력합니다."""
+    creds = get_credentials()
+    client = AnalyticsAdminServiceClient(credentials=creds)
+
+    print(f"\n{'=' * 70}")
+    print("  Google Analytics 계정 및 속성 목록")
+    print(f"{'=' * 70}\n")
+
+    try:
+        accounts = client.list_accounts()
+        for account in accounts:
+            print(f"계정: {account.display_name}")
+            print(f"  ID: {account.name}")
+
+            # 해당 계정의 속성 목록
+            from google.analytics.admin_v1beta.types import ListPropertiesRequest
+            properties_request = ListPropertiesRequest(
+                filter=f"parent:{account.name}"
+            )
+            properties = client.list_properties(request=properties_request)
+            for prop in properties:
+                prop_id = prop.name.split('/')[-1]
+                print(f"\n  속성: {prop.display_name}")
+                print(f"    Property ID: {prop_id}")
+                print(f"    Full name: {prop.name}")
+            print()
+
+    except Exception as e:
+        print(f"오류: {e}")
+        print("\nGoogle Analytics Admin API가 활성화되어 있는지 확인하세요:")
+        print("https://console.developers.google.com/apis/api/analyticsadmin.googleapis.com/overview")
+
+
+def run_report(property_id: str, days: int = 7):
+    """기본 트래픽 리포트를 실행합니다."""
+    creds = get_credentials()
+    client = BetaAnalyticsDataClient(credentials=creds)
+
+    end_date = datetime.now() - timedelta(days=1)
+    start_date = end_date - timedelta(days=days)
+
+    request = RunReportRequest(
+        property=f"properties/{property_id}",
+        date_ranges=[DateRange(
+            start_date=start_date.strftime('%Y-%m-%d'),
+            end_date=end_date.strftime('%Y-%m-%d'),
+        )],
+        dimensions=[Dimension(name="date")],
+        metrics=[
+            Metric(name="sessions"),
+            Metric(name="activeUsers"),
+            Metric(name="screenPageViews"),
+            Metric(name="bounceRate"),
+            Metric(name="averageSessionDuration"),
+        ],
+    )
+
+    try:
+        response = client.run_report(request)
+
+        print(f"\n{'=' * 80}")
+        print(f"  트래픽 리포트: Property {property_id}")
+        print(f"  기간: {start_date.strftime('%Y-%m-%d')} ~ {end_date.strftime('%Y-%m-%d')}")
+        print(f"{'=' * 80}\n")
+
+        print(f"{'날짜':<12} {'세션':>10} {'사용자':>10} {'페이지뷰':>10} {'이탈률':>10} {'평균시간':>10}")
+        print("-" * 80)
+
+        for row in response.rows:
+            date = row.dimension_values[0].value
+            sessions = row.metric_values[0].value
+            users = row.metric_values[1].value
+            pageviews = row.metric_values[2].value
+            bounce_rate = float(row.metric_values[3].value) * 100
+            avg_duration = float(row.metric_values[4].value)
+
+            print(f"{date:<12} {sessions:>10} {users:>10} {pageviews:>10} {bounce_rate:>9.1f}% {avg_duration:>9.1f}s")
+
+        # 합계
+        if response.totals:
+            print("-" * 80)
+            totals = response.totals[0]
+            print(f"{'합계':<12} {totals.metric_values[0].value:>10} {totals.metric_values[1].value:>10} {totals.metric_values[2].value:>10}")
+
+    except Exception as e:
+        print(f"오류: {e}")
+        print("\nGoogle Analytics Data API가 활성화되어 있는지 확인하세요:")
+        print("https://console.developers.google.com/apis/api/analyticsdata.googleapis.com/overview")
+
+
+def run_pages_report(property_id: str, days: int = 7):
+    """페이지별 성과 리포트를 실행합니다."""
+    creds = get_credentials()
+    client = BetaAnalyticsDataClient(credentials=creds)
+
+    end_date = datetime.now() - timedelta(days=1)
+    start_date = end_date - timedelta(days=days)
+
+    request = RunReportRequest(
+        property=f"properties/{property_id}",
+        date_ranges=[DateRange(
+            start_date=start_date.strftime('%Y-%m-%d'),
+            end_date=end_date.strftime('%Y-%m-%d'),
+        )],
+        dimensions=[Dimension(name="pagePath")],
+        metrics=[
+            Metric(name="screenPageViews"),
+            Metric(name="activeUsers"),
+            Metric(name="averageSessionDuration"),
+        ],
+        limit=50,
+    )
+
+    try:
+        response = client.run_report(request)
+
+        print(f"\n{'=' * 90}")
+        print(f"  페이지별 성과: Property {property_id}")
+        print(f"  기간: {start_date.strftime('%Y-%m-%d')} ~ {end_date.strftime('%Y-%m-%d')}")
+        print(f"{'=' * 90}\n")
+
+        print(f"{'페이지뷰':>10} {'사용자':>10} {'평균시간':>10}  페이지 경로")
+        print("-" * 90)
+
+        for row in response.rows:
+            page_path = row.dimension_values[0].value
+            pageviews = row.metric_values[0].value
+            users = row.metric_values[1].value
+            avg_duration = float(row.metric_values[2].value)
+
+            print(f"{pageviews:>10} {users:>10} {avg_duration:>9.1f}s  {page_path[:60]}")
+
+        print(f"\n총 {len(response.rows)}개 페이지")
+
+    except Exception as e:
+        print(f"오류: {e}")
+
+
+def run_sources_report(property_id: str, days: int = 7):
+    """트래픽 소스별 성과 리포트를 실행합니다."""
+    creds = get_credentials()
+    client = BetaAnalyticsDataClient(credentials=creds)
+
+    end_date = datetime.now() - timedelta(days=1)
+    start_date = end_date - timedelta(days=days)
+
+    request = RunReportRequest(
+        property=f"properties/{property_id}",
+        date_ranges=[DateRange(
+            start_date=start_date.strftime('%Y-%m-%d'),
+            end_date=end_date.strftime('%Y-%m-%d'),
+        )],
+        dimensions=[
+            Dimension(name="sessionSource"),
+            Dimension(name="sessionMedium"),
+        ],
+        metrics=[
+            Metric(name="sessions"),
+            Metric(name="activeUsers"),
+            Metric(name="screenPageViews"),
+        ],
+        limit=30,
+    )
+
+    try:
+        response = client.run_report(request)
+
+        print(f"\n{'=' * 80}")
+        print(f"  트래픽 소스별 성과: Property {property_id}")
+        print(f"  기간: {start_date.strftime('%Y-%m-%d')} ~ {end_date.strftime('%Y-%m-%d')}")
+        print(f"{'=' * 80}\n")
+
+        print(f"{'세션':>10} {'사용자':>10} {'페이지뷰':>10}  소스 / 매체")
+        print("-" * 80)
+
+        for row in response.rows:
+            source = row.dimension_values[0].value
+            medium = row.dimension_values[1].value
+            sessions = row.metric_values[0].value
+            users = row.metric_values[1].value
+            pageviews = row.metric_values[2].value
+
+            print(f"{sessions:>10} {users:>10} {pageviews:>10}  {source} / {medium}")
+
+    except Exception as e:
+        print(f"오류: {e}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Google Analytics Data API CLI (GA4)')
+    subparsers = parser.add_subparsers(dest='command', help='명령어')
+
+    # accounts 명령어
+    subparsers.add_parser('accounts', help='계정 및 속성 목록')
+
+    # report 명령어
+    report_parser = subparsers.add_parser('report', help='트래픽 리포트')
+    report_parser.add_argument('property_id', help='GA4 Property ID (숫자만)')
+    report_parser.add_argument('--days', type=int, default=7, help='조회 기간 (일)')
+
+    # pages 명령어
+    pages_parser = subparsers.add_parser('pages', help='페이지별 성과')
+    pages_parser.add_argument('property_id', help='GA4 Property ID (숫자만)')
+    pages_parser.add_argument('--days', type=int, default=7, help='조회 기간 (일)')
+
+    # sources 명령어
+    sources_parser = subparsers.add_parser('sources', help='트래픽 소스별 성과')
+    sources_parser.add_argument('property_id', help='GA4 Property ID (숫자만)')
+    sources_parser.add_argument('--days', type=int, default=7, help='조회 기간 (일)')
+
+    args = parser.parse_args()
+
+    if args.command == 'accounts':
+        list_accounts()
+    elif args.command == 'report':
+        run_report(args.property_id, args.days)
+    elif args.command == 'pages':
+        run_pages_report(args.property_id, args.days)
+    elif args.command == 'sources':
+        run_sources_report(args.property_id, args.days)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/bin/gsc
+++ b/bin/gsc
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""
+Google Search Console API 클라이언트
+
+사용법:
+    gsc sites                           # 등록된 사이트 목록
+    gsc query <site_url>                # 검색 성능 데이터 조회
+    gsc query <site_url> --days 30      # 최근 30일 데이터
+    gsc query <site_url> --by-date      # 날짜별 조회
+
+설정:
+    1. Google Cloud Console에서 OAuth 2.0 클라이언트 ID 생성
+    2. 클라이언트 시크릿 JSON 파일 다운로드
+    3. 환경변수 설정: export GOOGLE_CLIENT_SECRET=~/.config/google/client_secret.json
+    4. 첫 실행 시 브라우저에서 OAuth 인증 수행 (토큰 자동 저장)
+"""
+
+import argparse
+import os
+import pickle
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+
+try:
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+    from google_auth_oauthlib.flow import InstalledAppFlow
+    from googleapiclient.discovery import build
+except ImportError:
+    print("필수 패키지가 설치되어 있지 않습니다. 다음 명령어로 설치하세요:")
+    print("  pip install google-auth google-auth-oauthlib google-api-python-client")
+    sys.exit(1)
+
+# API 스코프
+SCOPES = ['https://www.googleapis.com/auth/webmasters.readonly']
+
+# 인증 파일 경로
+CLIENT_SECRET_FILE = os.environ.get(
+    'GOOGLE_CLIENT_SECRET',
+    os.path.expanduser('~/.config/google/client_secret.json')
+)
+TOKEN_FILE = os.path.expanduser('~/.config/gsc/token.pickle')
+
+
+def get_credentials():
+    """OAuth 2.0 인증을 수행하고 credentials를 반환합니다."""
+    creds = None
+    token_path = Path(TOKEN_FILE)
+
+    # 클라이언트 시크릿 파일 확인
+    if not os.path.exists(CLIENT_SECRET_FILE):
+        print(f"오류: 클라이언트 시크릿 파일을 찾을 수 없습니다: {CLIENT_SECRET_FILE}")
+        print()
+        print("설정 방법:")
+        print("  1. Google Cloud Console에서 OAuth 2.0 클라이언트 ID 생성")
+        print("  2. 클라이언트 시크릿 JSON 파일 다운로드")
+        print("  3. 파일을 ~/.config/google/client_secret.json에 저장")
+        print("     또는 GOOGLE_CLIENT_SECRET 환경변수로 경로 지정")
+        sys.exit(1)
+
+    # 저장된 토큰이 있으면 로드
+    if token_path.exists():
+        with open(token_path, 'rb') as token:
+            creds = pickle.load(token)
+
+    # 토큰이 없거나 만료되었으면 새로 인증
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRET_FILE, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        # 토큰 저장
+        token_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(token_path, 'wb') as token:
+            pickle.dump(creds, token)
+
+    return creds
+
+
+def get_service():
+    """Search Console API 서비스 객체를 반환합니다."""
+    creds = get_credentials()
+    return build('searchconsole', 'v1', credentials=creds)
+
+
+def list_sites():
+    """등록된 사이트 목록을 출력합니다."""
+    service = get_service()
+    response = service.sites().list().execute()
+
+    sites = response.get('siteEntry', [])
+    if not sites:
+        print("등록된 사이트가 없습니다.")
+        return
+
+    print(f"\n{'=' * 60}")
+    print("  등록된 사이트 목록")
+    print(f"{'=' * 60}\n")
+
+    for site in sites:
+        url = site.get('siteUrl', '')
+        permission = site.get('permissionLevel', '')
+        print(f"  {url}")
+        print(f"    권한: {permission}\n")
+
+
+def query_search_analytics(site_url: str, days: int = 7, dimensions: list = None):
+    """검색 성능 데이터를 조회합니다."""
+    service = get_service()
+
+    end_date = datetime.now() - timedelta(days=3)  # 최근 3일은 데이터 불완전
+    start_date = end_date - timedelta(days=days)
+
+    if dimensions is None:
+        dimensions = ['query', 'page']
+
+    request_body = {
+        'startDate': start_date.strftime('%Y-%m-%d'),
+        'endDate': end_date.strftime('%Y-%m-%d'),
+        'dimensions': dimensions,
+        'rowLimit': 100,
+    }
+
+    response = service.searchanalytics().query(
+        siteUrl=site_url,
+        body=request_body
+    ).execute()
+
+    rows = response.get('rows', [])
+
+    print(f"\n{'=' * 80}")
+    print(f"  검색 성능 데이터: {site_url}")
+    print(f"  기간: {start_date.strftime('%Y-%m-%d')} ~ {end_date.strftime('%Y-%m-%d')}")
+    print(f"{'=' * 80}\n")
+
+    if not rows:
+        print("  데이터가 없습니다.")
+        return
+
+    # 헤더
+    print(f"{'클릭':>8} {'노출':>10} {'CTR':>8} {'순위':>8}  검색어 / 페이지")
+    print("-" * 80)
+
+    for row in rows[:50]:  # 상위 50개만 출력
+        keys = row.get('keys', [])
+        clicks = row.get('clicks', 0)
+        impressions = row.get('impressions', 0)
+        ctr = row.get('ctr', 0) * 100
+        position = row.get('position', 0)
+
+        query = keys[0] if len(keys) > 0 else ''
+        page = keys[1] if len(keys) > 1 else ''
+
+        print(f"{clicks:>8} {impressions:>10} {ctr:>7.1f}% {position:>8.1f}  {query[:30]}")
+        if page:
+            print(f"{' ' * 40}  {page[:60]}")
+
+    print(f"\n총 {len(rows)}개 행")
+
+
+def query_by_date(site_url: str, days: int = 30):
+    """날짜별 검색 성능 데이터를 조회합니다."""
+    service = get_service()
+
+    end_date = datetime.now() - timedelta(days=3)
+    start_date = end_date - timedelta(days=days)
+
+    request_body = {
+        'startDate': start_date.strftime('%Y-%m-%d'),
+        'endDate': end_date.strftime('%Y-%m-%d'),
+        'dimensions': ['date'],
+        'rowLimit': 1000,
+    }
+
+    response = service.searchanalytics().query(
+        siteUrl=site_url,
+        body=request_body
+    ).execute()
+
+    rows = response.get('rows', [])
+
+    print(f"\n{'=' * 60}")
+    print(f"  날짜별 검색 성능: {site_url}")
+    print(f"{'=' * 60}\n")
+
+    print(f"{'날짜':<12} {'클릭':>8} {'노출':>10} {'CTR':>8} {'평균순위':>8}")
+    print("-" * 60)
+
+    for row in rows:
+        date = row.get('keys', [''])[0]
+        clicks = row.get('clicks', 0)
+        impressions = row.get('impressions', 0)
+        ctr = row.get('ctr', 0) * 100
+        position = row.get('position', 0)
+
+        print(f"{date:<12} {clicks:>8} {impressions:>10} {ctr:>7.1f}% {position:>8.1f}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Google Search Console CLI')
+    subparsers = parser.add_subparsers(dest='command', help='명령어')
+
+    # sites 명령어
+    subparsers.add_parser('sites', help='등록된 사이트 목록')
+
+    # query 명령어
+    query_parser = subparsers.add_parser('query', help='검색 성능 데이터 조회')
+    query_parser.add_argument('site_url', help='사이트 URL (예: https://example.com/)')
+    query_parser.add_argument('--days', type=int, default=7, help='조회 기간 (일)')
+    query_parser.add_argument('--by-date', action='store_true', help='날짜별 조회')
+
+    args = parser.parse_args()
+
+    if args.command == 'sites':
+        list_sites()
+    elif args.command == 'query':
+        if args.by_date:
+            query_by_date(args.site_url, args.days)
+        else:
+            query_search_analytics(args.site_url, args.days)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/skills/integrations/google-analytics-cli.md
+++ b/skills/integrations/google-analytics-cli.md
@@ -1,0 +1,203 @@
+---
+name: google-analytics-cli
+description: Google Analytics (GA4) 및 Search Console 데이터 조회 시 사용
+tags: [google, analytics, search-console, seo, cli, integration]
+---
+
+# Google Analytics & Search Console CLI
+
+## 개요
+
+Google Analytics Data API (GA4) 및 Search Console API에 접근하기 위한 CLI 도구입니다.
+
+| 서비스 | CLI | 위치 |
+|--------|-----|------|
+| Google Analytics | `ga` | `bin/ga` |
+| Search Console | `gsc` | `bin/gsc` |
+
+## 초기 설정
+
+### 1. Google Cloud Console 설정
+
+1. [Google Cloud Console](https://console.cloud.google.com/) 접속
+2. 프로젝트 생성 또는 선택
+3. APIs & Services > Library에서 API 활성화:
+   - Google Analytics Data API
+   - Google Analytics Admin API
+   - Search Console API
+4. APIs & Services > Credentials > Create Credentials > OAuth 2.0 Client ID
+   - Application type: Desktop app
+   - 생성된 클라이언트 시크릿 JSON 파일 다운로드
+
+### 2. 클라이언트 시크릿 설정
+
+```bash
+# 디렉토리 생성
+mkdir -p ~/.config/google
+
+# 다운로드한 JSON 파일 이동
+mv ~/Downloads/client_secret_*.json ~/.config/google/client_secret.json
+
+# 또는 환경변수로 경로 지정
+export GOOGLE_CLIENT_SECRET=~/.config/google/client_secret.json
+```
+
+### 3. Python 패키지 설치
+
+```bash
+pip install google-auth google-auth-oauthlib google-api-python-client google-analytics-data google-analytics-admin
+```
+
+### 4. 첫 실행 (OAuth 인증)
+
+```bash
+# 첫 실행 시 브라우저에서 Google 계정 인증
+ga accounts
+
+# 인증 완료 후 토큰이 자동 저장됨
+# - GA 토큰: ~/.config/ga/token.pickle
+# - GSC 토큰: ~/.config/gsc/token.pickle
+```
+
+## Google Analytics CLI (`ga`)
+
+### 명령어
+
+```bash
+ga <command> [args]
+```
+
+| 명령어 | 설명 |
+|--------|------|
+| `accounts` | 계정 및 속성 목록 |
+| `report <property_id>` | 트래픽 리포트 (일별 세션, 사용자, 페이지뷰) |
+| `pages <property_id>` | 페이지별 성과 |
+| `sources <property_id>` | 트래픽 소스별 성과 |
+
+### 사용 예시
+
+```bash
+# 계정 및 Property ID 확인
+ga accounts
+
+# 최근 7일 트래픽 리포트
+ga report 451236681
+
+# 최근 30일 트래픽 리포트
+ga report 451236681 --days 30
+
+# 페이지별 성과 (Top 50)
+ga pages 451236681 --days 30
+
+# 트래픽 소스별 성과
+ga sources 451236681 --days 30
+```
+
+### 주요 Property ID
+
+| 서비스 | Property ID | 설명 |
+|--------|-------------|------|
+| QueryPie Homepage | 451239708 | 홈페이지 |
+| ACP Docs | 522469891 | 문서 사이트 |
+| ACP Application | 451236681 | 웹 콘솔 |
+
+### 출력 예시
+
+```
+================================================================================
+  트래픽 리포트: Property 451236681
+  기간: 2026-01-24 ~ 2026-01-31
+================================================================================
+
+날짜            세션       사용자     페이지뷰        이탈률       평균시간
+--------------------------------------------------------------------------------
+20260127        5210       1890      46302       10.9%     532.5s
+20260128        4909       1812      43005       11.1%     545.7s
+```
+
+## Search Console CLI (`gsc`)
+
+### 명령어
+
+```bash
+gsc <command> [args]
+```
+
+| 명령어 | 설명 |
+|--------|------|
+| `sites` | 등록된 사이트 목록 |
+| `query <site_url>` | 검색 성능 데이터 (검색어, 페이지별) |
+| `query <site_url> --by-date` | 날짜별 검색 성능 |
+
+### 사용 예시
+
+```bash
+# 등록된 사이트 목록
+gsc sites
+
+# 최근 7일 검색 성능 (검색어/페이지별)
+gsc query "https://www.querypie.com/"
+
+# 최근 30일 검색 성능
+gsc query "https://www.querypie.com/" --days 30
+
+# 날짜별 검색 성능
+gsc query "https://www.querypie.com/" --by-date --days 30
+```
+
+### 출력 예시
+
+```
+================================================================================
+  검색 성능 데이터: https://www.querypie.com/
+  기간: 2026-01-21 ~ 2026-01-28
+================================================================================
+
+    클릭         노출      CTR       순위  검색어 / 페이지
+--------------------------------------------------------------------------------
+      15        1234     1.2%       8.5  querypie
+                                         https://www.querypie.com/
+```
+
+## 주요 지표 정의
+
+### Google Analytics
+
+| 지표 | 정의 |
+|------|------|
+| Sessions (세션) | 사용자의 방문 단위 (30분 비활동 시 새 세션) |
+| Active Users (사용자) | 고유 사용자 수 (쿠키 기반, 중복 제거) |
+| DAU | Daily Active Users - 하루 고유 사용자 수 |
+| Bounce Rate (이탈률) | 단일 페이지 세션 비율 |
+| Avg. Session Duration | 평균 세션 시간 |
+
+### Search Console
+
+| 지표 | 정의 |
+|------|------|
+| Clicks (클릭) | 검색 결과에서 사이트로 이동한 클릭 수 |
+| Impressions (노출) | 검색 결과에 표시된 횟수 |
+| CTR | Click-Through Rate = 클릭 / 노출 |
+| Position (순위) | 검색 결과 평균 게재 순위 |
+
+## 토큰 관리
+
+인증 토큰은 다음 위치에 저장됩니다:
+
+| 서비스 | 토큰 위치 |
+|--------|----------|
+| Google Analytics | `~/.config/ga/token.pickle` |
+| Search Console | `~/.config/gsc/token.pickle` |
+
+토큰 갱신이 필요한 경우 해당 파일을 삭제하고 다시 실행하면 됩니다:
+
+```bash
+rm ~/.config/ga/token.pickle
+ga accounts  # 브라우저에서 재인증
+```
+
+## 참고 링크
+
+- [Google Analytics Data API](https://developers.google.com/analytics/devguides/reporting/data/v1)
+- [Google Analytics Admin API](https://developers.google.com/analytics/devguides/config/admin/v1)
+- [Search Console API](https://developers.google.com/webmaster-tools/search-console-api-original)


### PR DESCRIPTION
## Summary
- `bin/ga`: Google Analytics Data API (GA4) CLI 도구
- `bin/gsc`: Google Search Console CLI 도구
- `skills/integrations/google-analytics-cli.md`: 사용 가이드 Skill 문서

## 주요 기능

### Google Analytics (`ga`)
- `accounts`: 계정/속성 목록
- `report <property_id>`: 트래픽 리포트 (세션, 사용자, 페이지뷰)
- `pages <property_id>`: 페이지별 성과
- `sources <property_id>`: 트래픽 소스별 성과

### Search Console (`gsc`)
- `sites`: 등록된 사이트 목록
- `query <site_url>`: 검색 성능 데이터

## 인증 설정
- 클라이언트 시크릿: `~/.config/google/client_secret.json`
- 또는 `GOOGLE_CLIENT_SECRET` 환경변수
- 토큰은 `~/.config/ga/` 및 `~/.config/gsc/`에 자동 저장
- Git에 토큰/시크릿 포함되지 않음

🤖 Generated with [Claude Code](https://claude.com/claude-code)