### PR TITLE
docs(skill): main 브랜치 직접 커밋 금지 규칙 추가

### DIFF
--- a/skills/ops/branch-workflow.md
+++ b/skills/ops/branch-workflow.md
@@ -10,6 +10,20 @@ tags: [git, branch, pr, workflow]
 
 Local branch를 최소로 유지하며 항상 최신 main 위에서 작업하는 워크플로우.
 
+## 필수 규칙
+
+> **main 브랜치에 직접 커밋 금지**
+>
+> 커밋 전 반드시 현재 브랜치를 확인하고, feature 브랜치에서 작업할 것.
+
+```bash
+# 커밋 전 브랜치 확인 (필수)
+git branch --show-current
+
+# main이면 즉시 feature 브랜치 생성
+git checkout -b <prefix>/<descriptive-name>
+```
+
 ## 적용 시점
 
 - 새로운 PR 작업을 시작할 때
@@ -68,6 +82,7 @@ git checkout -b <prefix>/<descriptive-name>
 
 | 실수 | 해결 |
 |------|------|
+| **main에 직접 커밋** | 커밋 전 `git branch --show-current` 확인 필수 |
 | main 업데이트 없이 브랜치 생성 | 항상 `git pull` 먼저 |
 | 머지된 브랜치 방치 | PR 상태 확인 후 삭제 |
 | 원격 추적 브랜치 누적 | `git remote prune origin` 실행 |


### PR DESCRIPTION
## Summary
- branch-workflow.md에 필수 규칙 섹션 추가
- 커밋 전 현재 브랜치 확인 필수 (`git branch --show-current`)
- main 브랜치에서는 반드시 feature 브랜치 생성 후 작업

## Test plan
- [x] 규칙 문서 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)