### PR TITLE
docs(ops): main 직접 push 금지 및 PR 닫기 규칙 추가

### DIFF
--- a/skills/ops/commit.md
+++ b/skills/ops/commit.md
@@ -8,6 +8,24 @@ tags: [git, commit, pr, workflow]
 
 ## 핵심 규칙
 
+### 0. main 브랜치에 직접 push 금지 (절대 규칙)
+
+**어떤 경우에도 main 브랜치에 직접 push하지 않습니다.**
+
+- 모든 변경사항은 반드시 별도 브랜치에서 작업 후 PR을 통해 병합
+- 직접 push가 필요해 보이는 상황에서도 예외 없음
+- 실수로 main에 커밋한 경우: 즉시 `git reset`으로 되돌리고 새 브랜치 생성
+
+```bash
+# 실수로 main에 커밋한 경우 복구
+git checkout main
+git reset --soft HEAD~1  # 마지막 커밋 취소 (변경사항 유지)
+git checkout -b <new-branch-name>
+git commit -m "..."
+git push -u origin <new-branch-name>
+# 그 후 PR 생성
+```
+
 ### 1. 커밋 전 PR 병합 여부 확인 (필수)
 
 기존 브랜치에 커밋할 때, 반드시 해당 브랜치의 PR이 이미 병합되었는지 확인합니다.
@@ -70,6 +88,7 @@ EOF
 
 ## 체크리스트
 
+- [ ] **main 브랜치가 아닌지 확인했는가?** (절대 규칙)
 - [ ] PR 병합 여부 확인했는가?
 - [ ] Co-Authored-By 트레일러가 올바른가? (`Atlas <atlas@jk.agent>`)
 - [ ] 커밋 메시지가 변경 내용을 명확히 설명하는가?

--- a/skills/ops/create-pr.md
+++ b/skills/ops/create-pr.md
@@ -22,7 +22,14 @@ tags: [pr, git, github, workflow, bot]
 |-----------|-------------|------|
 | PR 승인 | `gh pr review --approve` | 코드 리뷰는 사람이 수행 |
 | PR 병합 | `gh pr merge` | 병합 결정은 사람이 수행 |
+| PR 닫기 | `gh pr close` | 명시적 지시 없이 닫기 금지 |
 | 리뷰 코멘트로 승인 | `gh pr review --comment "LGTM"` | 승인 의도의 코멘트 금지 |
+
+### PR 닫기 규칙
+
+- **명시적으로 Close를 지시하기 전에는 PR을 닫지 않습니다**
+- PR에 문제가 있는 경우: 닫지 말고 수정 (rebase, force push 등)
+- PR 재활용 우선: 새 PR 생성보다 기존 PR 수정 선호
 
 **적용 범위**: querypie-mono를 포함한 **모든 저장소**의 PR
 


### PR DESCRIPTION
## Summary
- `commit.md`: main 브랜치 직접 push 금지 규칙 추가 (핵심 규칙 0번)
- `create-pr.md`: 명시적 지시 없이 PR 닫기 금지 규칙 추가

## 변경 내용

### commit.md
- 핵심 규칙 0번으로 main 브랜치 직접 push 금지 절대 규칙 명시
- 실수로 main에 커밋한 경우 복구 방법 안내
- 체크리스트에 main 브랜치 확인 항목 추가

### create-pr.md
- 절대 금지 사항에 PR 닫기 추가
- PR 닫기 규칙: 명시적 지시 전 닫기 금지, PR 재활용 우선

🤖 Generated with [Claude Code](https://claude.com/claude-code)