### PR TITLE
docs(skill): Bash 스타일 가이드 v2 - 추가 50개 스크립트 분석

### DIFF
--- a/skills/coding/bash-scripting.md
+++ b/skills/coding/bash-scripting.md
@@ -589,6 +589,56 @@ fi
 # FIXME: 수정이 필요한 부분
 ```
 
+## Glob 패턴 for 루프
+
+```bash
+# 여러 glob 패턴으로 순회
+for testcase in testcases/[0-9]* testcases/lists testcases/panels; do
+  pushd "$testcase"
+  (set -x; cp output.mdx expected.mdx)  # 서브쉘에서 한 줄 xtrace
+  popd
+done
+```
+
+## 옵션 수집 배열
+
+```bash
+# 옵션을 배열에 누적하여 명령에 전달
+PACKER_OPTIONS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -on-error=*)
+      PACKER_OPTIONS+=("$1")
+      shift
+      ;;
+    --abort)
+      PACKER_OPTIONS+=("-on-error=abort")
+      shift
+      ;;
+    *) shift ;;
+  esac
+done
+
+# 배열을 명령 인자로 전달
+packer build "${PACKER_OPTIONS[@]}" template.pkr.hcl
+```
+
+## tee로 로그 파일 생성
+
+```bash
+# stdout 출력하면서 파일로도 저장
+log::do packer build template.pkr.hcl |
+  tee log/packer-"${version}"-"${distro}".log
+```
+
+## 여러 필수 인자 검증
+
+```bash
+local var1=${1:-} var2=${2:-}
+[[ -n "$var1" && -n "$var2" ]] || print_usage_and_exit 1
+```
+
 ## Git CI 스크립트 패턴
 
 ```bash


### PR DESCRIPTION
## Summary
- 3개 저장소에서 **50개** bash script 추가 분석
- 기존 가이드에 새로운 패턴 추가
- 5회에 걸친 반복적 개선

## 분석한 저장소
- tpm: 20개
- querypie-mono: 19개
- querypie-docs: 11개

## 각 Round별 변경사항

### Round 1
- Docker entrypoint 고급 패턴: `source || true`, `command -v`, `set --`
- Markdown 테이블 출력 (CI Summary용)
- 포맷된 숫자 시퀀스: `seq -f "%04g"`

### Round 2
- JSON 배열 동적 생성 (CI matrix용)
- IFS로 문자열 분리: `IFS=':/' read -ra parts`
- 배열 마지막 요소: `${parts[-1]}`
- 서브쉘에서 xtrace 사용

### Round 3
- 파일명 안전 변환: `tr '/:' '__'`
- Python venv 활성화 패턴
- `/dev/tty`로 파이프 실행 시 사용자 입력
- 마지막 줄 newline 처리
- `validate_environment` 함수 패턴

### Round 4
- 전역 배열로 패키지 목록 정의
- Parameter Expansion 문자열 파싱
- Retry 루프 패턴
- Here-string으로 변수 순회
- 바이너리 파일 검증

### Round 5
- Glob 패턴 for 루프
- 옵션 수집 배열 패턴
- tee로 로그 파일 생성
- 여러 필수 인자 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)