### PR TITLE
fix(bin): git-cleanup-branches에서 현재 브랜치 삭제 오류 수정

### DIFF
--- a/bin/git-cleanup-branches
+++ b/bin/git-cleanup-branches
@@ -139,6 +139,17 @@ def has_remote_branch(repo_path: Path, branch: str) -> bool:
     return code == 0
 
 
+def get_current_branch(repo_path: Path) -> str | None:
+    """Get the currently checked out branch."""
+    code, stdout, _ = run_command(
+        ["git", "branch", "--show-current"],
+        cwd=str(repo_path),
+    )
+    if code != 0 or not stdout:
+        return None
+    return stdout.strip()
+
+
 def fetch_repo(repo_path: Path) -> bool:
     """Fetch and prune remote tracking branches."""
     code, _, stderr = run_command(
@@ -152,7 +163,18 @@ def fetch_repo(repo_path: Path) -> bool:
 
 
 def delete_branch(repo_path: Path, branch: str) -> bool:
-    """Delete a local branch."""
+    """Delete a local branch, switching to base branch first if necessary."""
+    current = get_current_branch(repo_path)
+    if current == branch:
+        base_branch = get_base_branch(repo_path)
+        code, _, stderr = run_command(
+            ["git", "checkout", base_branch],
+            cwd=str(repo_path),
+        )
+        if code != 0:
+            print(f"    ! checkout {base_branch} failed: {stderr}")
+            return False
+
     code, _, stderr = run_command(
         ["git", "branch", "-D", branch],
         cwd=str(repo_path),


### PR DESCRIPTION
## Summary
- 삭제 대상 브랜치가 현재 checkout된 브랜치인 경우 base branch로 먼저 checkout 후 삭제
- `get_current_branch()` 함수 추가
- worktree에서 사용 중인 브랜치 삭제 실패 문제 해결

## 문제 상황
```
error: cannot delete branch 'feat/xxx' used by worktree at '/Users/jk/workspace/repo'
```

## 해결 방법
삭제 전에 현재 브랜치인지 확인하고, 맞다면 main/develop으로 checkout 후 삭제

## Test plan
- [ ] `git-cleanup-branches --delete` 실행 시 현재 브랜치도 정상 삭제되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)