### PR TITLE
docs: www.querypie.com 404 URL 분석 리포트

### DIFF
--- a/reports/gsc-404-analysis-2026-02-06.md
+++ b/reports/gsc-404-analysis-2026-02-06.md
@@ -1,0 +1,194 @@
+# www.querypie.com 404 URL 분석 리포트
+
+- 생성: 2026-02-06
+- 데이터 소스: GSC "Not found (404)" 상세 URL (822건)
+
+## 요약
+
+www.querypie.com에서 Google이 크롤링 시 404 응답을 받는 URL 822개를 분석한 결과, **5개 카테고리**로 분류됩니다. 대부분은 사이트 리뉴얼/이전 과정에서 발생한 URL 변경이 원인이며, 301 리다이렉트 설정으로 해결 가능합니다.
+
+| 카테고리 | 건수 | 비중 | 긴급도 | 조치 |
+|----------|------|------|--------|------|
+| Resources (다국어) | 418 | 50.9% | 중 | URL 구조 변경 확인 → 301 리다이렉트 |
+| Docs (문서 이전) | 180 | 21.9% | 높 | docs.querypie.com으로 301 리다이렉트 |
+| Wiki (Confluence) | 113 | 13.7% | 중 | docs.querypie.com으로 매핑 또는 410 Gone |
+| Other (레거시/버그) | 26 | 3.2% | 낮 | 개별 처리 |
+| Soft 404 | 1 | 0.1% | 낮 | 콘텐츠 확인 |
+| **합계** | **822** | | | |
+
+## 크롤링 시점 분포
+
+Google이 **최근까지 활발히 재크롤** 하고 있어, 404가 지속적으로 인덱싱 품질에 영향을 미치고 있습니다.
+
+| 시기 | 건수 |
+|------|------|
+| 2026년 2월 | 17 |
+| 2026년 1월 | 229 |
+| 2025년 12월 | 201 |
+| 2025년 11월 | 337 |
+| 2025년 10월 이전 | 38 |
+
+---
+
+## 카테고리별 상세 분석
+
+### 1. Resources URL (418건) — 50.9%
+
+다국어 리소스 페이지 (블로그, 데모, 백서, 튜토리얼 등)가 404를 반환합니다.
+
+**URL 패턴:**
+
+| 경로 패턴 | 건수 |
+|-----------|------|
+| `/ko/resources/learn/...` | 125 |
+| `/ja/resources/learn/...` | 123 |
+| `/resources/learn/...` (en) | 72 |
+| `/en/resources/...` | 42 |
+| `/resources/discover/...` (en) | 42 |
+| 기타 locale | 14 |
+
+**하위 섹션 분포:**
+
+| 섹션 | 건수 |
+|------|------|
+| documentation (블로그/글로서리) | 117 |
+| demo (데모 영상) | 108 |
+| tutorials | 65 |
+| white-paper | 56 |
+| blog | 35 |
+| webinars | 22 |
+| certifications | 4 |
+| ai-data-discovery | 3 |
+
+**추정 원인:** 사이트 리뉴얼 시 `/resources/` 하위 URL 구조가 변경됨. 이전 URL에 대한 리다이렉트가 없음.
+
+**권장 조치:**
+1. 현재 사이트에서 동일 콘텐츠의 새 URL 매핑 테이블 작성
+2. 서버단 301 리다이렉트 규칙 추가 (패턴 기반)
+3. 사이트맵에서 이전 URL 제거
+
+---
+
+### 2. Docs URL (180건) — 21.9%
+
+`/docs/` 경로의 제품 문서가 www.querypie.com에서 404를 반환합니다. 이 문서들은 docs.querypie.com으로 이전된 것으로 추정됩니다.
+
+**언어별 분포:**
+
+| 경로 | 건수 |
+|------|------|
+| `/docs/ja/...` | 74 |
+| `/docs/ko/...` | 74 |
+| `/docs/en/...` | 32 |
+
+**문서 섹션 분포:**
+
+| 섹션 | 건수 |
+|------|------|
+| administrator-manual | 120 |
+| user-manual | 25 |
+| release-notes | 22 |
+| querypie-overview | 11 |
+
+**샘플 URL:**
+- `www.querypie.com/docs/ko/administrator-manual/multi-agent-limitations`
+- `www.querypie.com/docs/ja/release-notes/9120-91214/menu-improvement-guide-9120`
+- `www.querypie.com/docs/en/administrator-manual/audit/web-app-logs`
+
+**권장 조치:**
+1. `www.querypie.com/docs/*` → `docs.querypie.com/*` 301 리다이렉트 규칙 추가
+2. 경로 매핑 확인: `/docs/ko/...` → `docs.querypie.com/ko/...` 등 동일 구조인지 검증
+3. 사이트맵에서 `/docs/` URL 제거
+
+---
+
+### 3. Wiki/Confluence URL (113건) — 13.7%
+
+Confluence Wiki 페이지가 www.querypie.com 하위에서 서빙되다가 더 이상 존재하지 않습니다. 모두 `QCP` 스페이스.
+
+**URL 패턴:** `www.querypie.com/wiki/spaces/QCP/pages/{pageId}/{title}`
+
+**샘플 URL:**
+- `/wiki/spaces/QCP/pages/940015683/- Slack App Webhook`
+- `/wiki/spaces/QCP/pages/897810813/Troubleshooting - Aurora PostgreSQL as Target Database EN`
+- `/wiki/spaces/QCP/pages/1224048642/Untitled live doc 2025-08-13`
+
+**권장 조치:**
+1. docs.querypie.com에 동일 콘텐츠가 마이그레이션됐는지 확인
+2. 매핑 가능한 페이지: `wiki page → docs 페이지` 301 리다이렉트
+3. 매핑 불가한 페이지: HTTP 410 (Gone) 응답으로 변경하여 Google에 영구 삭제 알림
+4. `robots.txt`에 `/wiki/` 경로 Disallow 추가 (신규 크롤 방지)
+
+---
+
+### 4. 버그/비정상 URL (10건)
+
+프론트엔드 코드 버그로 생성된 비정상적인 URL입니다.
+
+| URL | 추정 원인 |
+|-----|----------|
+| `/jahttps://www.querypie.com/resources/...` (5건) | locale prefix `/ja` + 절대 URL 이중 결합 |
+| `/japr@querypie.com` | `/ja` + `pr@querypie.com` (mailto 링크 버그) |
+| `/kowww.allganize.ai` | `/ko` + 외부 URL (href 처리 버그) |
+| `/&` | 빈 href 또는 앰퍼샌드 인코딩 오류 |
+| `/pr@querypie.com` | mailto 링크가 href로 잘못 렌더링 |
+| `/render_html` | 내부 API 엔드포인트 노출 |
+
+**권장 조치:**
+1. **프론트엔드 코드 수정**: 다국어 URL 생성 로직에서 절대 URL/mailto 처리 버그 수정
+2. 이 URL들은 robots.txt로 차단하거나 410 응답
+
+---
+
+### 5. 레거시 페이지 (16건)
+
+사이트 리뉴얼 전 존재했던 페이지입니다.
+
+| 경로 패턴 | 건수 | 비고 |
+|-----------|------|------|
+| `/blog/...` | 2 | 구 블로그 URL |
+| `/company/...` | 5 | about, careers, tech-talk, bounty 등 |
+| `/customers/...` | 12 | 고객 사례 |
+| `/solutions/...` | 10 | 솔루션 페이지 |
+| `/download` | 1 | 다운로드 페이지 |
+| `/recruit/dotnet` | 1 | 채용 |
+| `/partners/become-a-partner` | 1 | 파트너십 |
+| `/bug-bounty-program/...` | 2 | 버그 바운티 |
+| `/tmp/http4kexample/` | 1 | 테스트 페이지 |
+
+**권장 조치:**
+1. 현재 사이트에 대응 페이지가 있으면 301 리다이렉트
+2. 없는 페이지는 사이트맵에서 제거
+
+---
+
+## 우선순위별 액션 플랜
+
+### P1 — 높음 (이번 주)
+
+| # | 액션 | 대상 | 예상 효과 |
+|---|------|------|----------|
+| 1 | `/docs/*` → `docs.querypie.com/*` 301 리다이렉트 | 180건 | 문서 SEO 가치 이전 |
+| 2 | 프론트엔드 locale URL 버그 수정 | 10건 | 신규 비정상 URL 생성 방지 |
+
+### P2 — 중간 (이번-다음 주)
+
+| # | 액션 | 대상 | 예상 효과 |
+|---|------|------|----------|
+| 3 | `/resources/` 리다이렉트 매핑 작성 | 418건 | 최대 카테고리 해소 |
+| 4 | `/wiki/` 경로 robots.txt Disallow + 410 응답 | 113건 | 불필요 크롤 차단 |
+
+### P3 — 낮음 (다음 주)
+
+| # | 액션 | 대상 | 예상 효과 |
+|---|------|------|----------|
+| 5 | 레거시 페이지 개별 리다이렉트 | 16건 | - |
+| 6 | 사이트맵에서 404 URL 일괄 제거 | 전체 | 크롤 예산 최적화 |
+
+---
+
+## 참고: 추가 분석 필요
+
+- **Page with redirect (1,227건)**: 별도 분석 필요. 리다이렉트 체인/사이트맵 정리 대상.
+- **Crawled - currently not indexed (96건)**: 콘텐츠 품질 또는 내부 링크 부족 가능성.
+- **Redirect error (18건)**: 잘못된 리다이렉트 설정 확인 필요.


### PR DESCRIPTION
## Summary

GSC에서 수집한 www.querypie.com의 404 URL 822건을 카테고리별로 분석한 리포트입니다.

### 분류 결과

| 카테고리 | 건수 | 비중 |
|----------|------|------|
| Resources (다국어 리소스) | 418 | 50.9% |
| Docs (문서 이전) | 180 | 21.9% |
| Wiki (Confluence) | 113 | 13.7% |
| 레거시/버그 URL | 27 | 3.3% |

### 주요 발견

- `/docs/*` → `docs.querypie.com` 이전 후 301 리다이렉트 미설정 (180건)
- 프론트엔드 locale 처리 버그로 `/jahttps://...` 같은 비정상 URL 생성 (10건)
- Google이 최근까지 활발히 재크롤 중 (2025.11~2026.02: 784건)

### 우선순위별 액션 플랜 포함

- P1: docs 리다이렉트 + 프론트엔드 버그 수정
- P2: resources 리다이렉트 매핑 + wiki 차단
- P3: 레거시 개별 처리 + 사이트맵 정리

🤖 Generated with [Claude Code](https://claude.com/claude-code)