### PR TITLE
docs: GSC 인덱싱 개선 프로젝트 진행 요약 및 데이터 백업

### DIFF
--- a/reports/data/gsc-detail-2026-02-06.json
+++ b/reports/data/gsc-detail-2026-02-06.json
@@ -1,0 +1,716 @@
+{
+  "generated_at": "2026-02-06T18:06:13.646200",
+  "sites": [
+    {
+      "label": "app.querypie.com",
+      "reasons": {
+        "Duplicate without user-selected canonical": {
+          "total": 145,
+          "collected": 145,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/b8dc27ab-d8dd-41ae-ab3d-c2256cb10eb8/chuncheon-1night-2day-travel-recommendation",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b20d3be7-3c3c-43a8-9947-466905f74c65/2025-fall-mens-fashion-coordination-trends",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/395635db-2fa8-4255-934d-b9085f19c5d4/it-worker-wrist-protection-exercises-equipment-guide",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bdbd52bb-2a2a-43a5-9b59-42ee0b363972/cryptocurrency-top10-daily-chart-analysis-bitcoin-ethereum",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cda0a024-8bc4-4e2c-b7ec-ae0d9135b400/youtube-premium-value-analysis-korean-pricing",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/825ef2cd-ae1f-4ee4-b4b5-15d6b7a94b89/korean-mens-fall-hair-style-guide-barber-request-tips",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fab857c8-2b6c-4c26-bee5-aa15e5d1076c/anyang-gunpo-uiwang-dating-spots-dim-lighting-restaurants",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/33b90907-b8f4-4199-91e8-211b984a127d/korean-couples-travel-destinations-public-transport-guide",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/abb5cba9-dbe5-48a5-906b-77fd01ab7cab/qa-terminology-list-korean-100-terms-explanation",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/abf9b2fe-0c79-469b-8885-944b63ca80c0/30-dae-saengil-seonmul-kakaotalk-seonmul-10-seon-gagyeok-chucheeon",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2f363124-beaa-4318-8d64-87443215c960/hongdae-escape-room-cafe-horror-themes-booking-times",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/36e122d6-3925-44be-8628-c8fdda62e283/kbo-team-selection-guide-for-beginners",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/49ec61d6-49fe-4f3d-be94-f6814ff0fa61/korean-saju-birth-time-estimation-using-past-events",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa273e70-baf1-4966-9e08-355982df8bc8/s3-bucket-policy-examples",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b2a81f7-a02d-40aa-b032-a45dc320e420/react-gof-design-patterns-examples",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2fa6d3dd-a6e8-4b35-a84c-ce7c1b7d728b/2025-korean-foreign-hiphop-trends-drake-future-popularity-discussion",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b49e7825-977b-4555-80d9-9c2af9bd2765/korean-instagram-photo-poses-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ec09669b-7521-4f06-a4ed-10fe9a640241/gwangmyeong-market-restaurant-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5732b25a-3014-4b99-b19b-9e8a6e364c8e/2026-korean-real-estate-market-forecast-prediction",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6549b671-0d4f-4eec-b403-3d4c87b2d8cb/boys-2-planet-top-9-winner-predictions-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/80c689e9-1db9-41ec-8d5c-a476f2770b81/qa-engineer-effective-report-writing-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cfa7690f-0d60-4a01-9e30-ad8b149aa442/schedule-meeting-with-jane-project-discussion-tuesday-nov-19-2pm",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e7d437d2-df53-4d73-bd96-8232d0a3268c/schedule-meeting-with-jane-wednesday",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0223a74c-0a57-414c-b57c-783e832ea1da/italian-pastrami-mortadella-sandwich-recipe-korea-shopping",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3671ea81-ac26-4abd-a931-dc40fac57a6e/apartment-dog-breed-recommendations-owner-personality-match",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3ee7c3e0-ee3b-47c9-85c2-896658ef3b36/best-places-to-visit-europe-travel-destinations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6ecda236-384e-4263-be46-dcd69d7c19ed/2025-3q-4q-movie-releases-korean-list-rating-table-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/26327be9-abe2-424b-88e5-4a8b1153f6b5/gangwondo-beach-recommendations-for-kids-swimming",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7e012e59-088b-4b07-be63-1dc4d33d5750/korean-music-recommendations-dopamine-songs-trending-kpop-hits-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f47fef57-0d1a-4d52-926d-9ce6d94f5f70/30s-employee-government-benefits-calendar-registration",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/98832e3f-e8bf-4a4b-a8e5-5af08b445eb0/hello-world-greeting",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9a1fa878-149c-4eb7-803d-e55c1b3aac23/korean-40s-health-self-care-program-for-office-workers",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/efb947cc-81d8-494a-9fa3-b670b0c2eeea/quantum-computers-bitcoin-encryption-threat-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8d005ec0-13c6-428f-9287-46ede82d34c7/qa-test-automation-tools-detailed-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ef9c7c5a-d923-408d-b79a-fc28a362a4df/korean-real-estate-investment-analysis-2025-apartment-market-forecast",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/23ccc5a3-008e-44a9-be45-7a6589158b07/wedding-guest-hair-makeup-ramada-sindorim-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/53cb4d0f-d4a9-4ba3-847b-bd69daec8a7d/how-to-invest-in-cryptocurrency-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9e58f90d-20a0-4741-9b61-1c05777c8d50/css-modern-features-learning-2025-beyond-css3",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5047a919-6311-4dd9-b4c6-f9248144d585/powell-august-fed-speech-september-rate-cut-market-sentiment-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8bcb7aea-489a-41ac-938b-c066dda8c119/coinness-bitcoin-ethereum-price-news-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/77dbd04d-993f-44ee-901f-036f46897ee0/parcel-hub-fraud-pattern-analysis-report",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d1e837c9-3401-4bf2-90dd-fe55a046e2f3/m7-magnificent-seven-stocks-analysis-investment-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/03b6b743-d337-4065-9976-bac466252209/bitcoin-investment-analysis-2025-price-forecast-macroeconomic-factors",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/984be0b4-3de0-4ede-949f-8875e74e96cc/korean-dermatology-treatment-recommendations-and-gangnam-clinic-events",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b72a5b0d-16cb-4133-afb7-2b792688c65b/4-week-plan-to-reduce-child-smartphone-screen-time-gradually",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/49c45100-1a31-4408-a3a1-6bb6c021fd2d/korean-oliveyoung-cosmetics-recommendation-with-pricing",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9c63757a-260c-4a9b-8b08-6401c2380977/quick-mbti-test-5-questions-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e919b4d0-39f4-43d1-8827-8023a16a20ef/best-budget-accommodations-tokyo-under-50-dollars-per-night",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0b212a83-f402-472f-add1-aa5e026d1666/san-francisco-weather-today-61f-partly-cloudy",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3c14c673-f1ff-4f80-ad2f-9ff519559972/world-top-10-travel-destinations-complete-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/32e16ae5-4bb6-4bcd-8106-ebe7245d6bef/finding-cheap-flights-tips-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d011d8d6-d842-4550-8611-39c42d2d384e/bluehands-search-bongcheon-dong-area",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e8cd8db8-3ae5-4727-85bf-6144080ecd55/chatgpt-latest-features-and-prompt-templates-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ecd9a808-d85b-40a9-8edd-ec8cecb5cfce/ai-era-talent-skills-technical-human-capabilities-job-market",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/95ebd3c6-b508-4b83-aa4a-174565007cf5/seoul-2025-q3-events-exhibitions-concerts-performances-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/65d85402-2f91-4dd3-9cf8-6a42c03b961f/2025-latest-kpop-dance-challenge-rankings-popularity",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/54b755e6-20a9-4fdf-97ec-f82ab1e3f18f/workplace-communication-methods-korean-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6d301136-0803-4808-b42b-72cf0c6da95d/how-to-lose-weight-fast-safely-evidence-based-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bfcb6ad6-3cf0-4c2a-94dd-829e149152fb/son-heung-min-mls-lafc-transfer-fee-salary-summary",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6c1fb6e5-141a-4c1e-848a-1cdd462aaf5a/creating-information-security-pledge-for-development-company",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/dc700168-d5ca-415b-9c11-fc90a0104716/graphic-design-reference-site-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cca77015-6466-4a7d-b398-568cf96cb2e5/kubernetes-k8s-basic-commands-kubectl-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e67b01a3-80b6-49b4-84d2-a9b91375423a/tylenol-acetaminophen-drug-interactions-contraindications",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/91b2ac1d-d0f9-4d9b-8fc6-555ef5c268ab/qa-testing-preparation-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/21652f0f-62a6-4e24-87b4-00b848e15914/office-worker-perfume-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5ba59bb2-977b-423c-85d6-3bbafb92103f/ashley-queens-recipe-tips-korean-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3649550f-ff00-424e-abd2-68a737340f2a/2025-5th-mirae-house-application-conditions-requirements",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4bdc1b8c-7225-4603-be66-d75e929ec969/korean-office-worker-business-manners-etiquette-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/80470600-55b9-46fa-a4b9-d169042ca456/kube-prometheus-stack-operator-rbac-cluster-permissions-security",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2b45d859-fedb-486c-bed5-de37936ab336/guide-to-better-sleep-hygiene-tips",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d5ddd8d2-2157-4f5b-8efe-4831be1f9cc4/coinbase-stock-investment-analysis-revenue-competition-bitcoin-volatility",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/1c6ed7be-b360-4a3f-b3cc-5b110d1805c1/hypertension-friendly-foods-korean-diet-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d80663e8-9477-40a1-a878-9b28d0228310/son-heung-min-style-changes-epl-to-mls-adaptation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/575fa631-e785-46e1-8de2-509495d1e951/research-zai-and-chatzai-compared-with-querypie-ai",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b542ff36-c1dd-461c-9eb1-5e3f29e64599/long-term-stock-investment-plan-for-child-born-2025-monthly-savings-strategy",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/24f86db4-525e-41d8-b366-1df31d6c1423/latest-ai-technology-trends-and-business-applications-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e6e2bd32-7f7d-4230-a70d-630049b3bdc9/shinbashi-yakitori-restaurant-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/23e781bb-0329-4e86-9d3f-fd59e0c476b0/suwon-dongtan-blind-date-romantic-venues-recommendation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/af436981-eebd-46de-b2e9-7c2056500b81/seoul-housing-support-policy-for-elderly-over-65-homeless-couples",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/06ae88d4-ea15-40ab-9d8c-e7c859ba9802/korean-ideal-type-personality-analysis-q-and-a",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fc27b752-0d76-4e68-b072-da005ee72127/korean-recipe-recommendations-with-available-ingredients",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4e543638-04be-4aed-8095-9974e08810c5/yeongdeungpo-market-restaurant-recommendations-honest-reviews",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d37f28be-2ed6-4347-adc8-572e4fba29ae/ai-era-automation-resistant-jobs-analysis-future-career-trends",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f56df22e-eca5-4496-afb6-d24782a07f10/cryptocurrency-stocks-coinbase-bitcoin-mining-investing-basics-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/711fbd9d-cbd3-4d32-9364-0f658786b0f5/korean-gold-price-inquiry-today",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/616e686b-ce72-41d8-b485-fda6f13432d9/new-york-vs-los-angeles-5-day-vacation-comparison",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/462c12e1-3962-4350-a536-0db5571208a5/travel-luggage-size-recommendations-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d3d589fd-082e-4f47-b635-863966e9a6ef/ankle-sprain-cold-hot-compress-treatment-advice",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7ee2df9d-9fe5-4b6c-b7d7-c6d19401e786/korean-fortune-telling-birth-chart-analysis-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/1351729a-ea37-4666-b4e3-05b247f9179a/san-francisco-weather-lookup-and-forecast",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2889eed3-0f02-437c-ac00-ae5f2f2cffaa/nintendo-2025-upcoming-games-list-korean-request",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3daa6132-c8be-44b0-adaa-dfc2e5e876ff/monitoring-tools-comparison-prometheus-vs-datadog-vs-newrelic",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f23432c0-244f-4df0-af82-c88bd37f1f9f/marriage-registration-disadvantages-and-loan-issues",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f6c5655a-1011-4522-8153-2e7f5c097570/korean-twenty-questions-guessing-hint-game",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa828aea-10ce-4516-8fad-be64d51c6c51/personal-color-consultation-deep-autumn-diagnosis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/335b8b75-6eb4-4711-8d91-98589b42559b/seoul-weather-forecast-partly-cloudy-17-celsius",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8d2b9c3a-1dd9-4b43-a60e-7e31a50d2622/bitcoin-market-cap-vs-gold-surpass-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a7c795df-7791-49dc-941b-79fd5d0df5fd/korean-user-requests-weather-forecasts-for-seoul-and-san-francisco-with-hourly-tables",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8276d11e-d2fe-4fc5-967c-1c03e6e8d17e/best-passive-income-ideas-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bd129b59-5ac2-4872-bbf7-4b08e958f848/busan-2-nights-3-days-winter-travel-plan-budget-100k-won-daily",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f62ccb30-0239-4949-8cb6-3febe748e160/budget-overseas-travel-destinations-korea-cost-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/34385240-8e1d-47ab-b768-ea457a331682/traditional-italian-carbonara-recipe-no-cream",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/96911063-59f3-4035-912a-f2d7405af3e0/tsa-liquid-restrictions-airplane-travel",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/35d00962-05f4-418f-ab9a-cf5bd57e5f25/korean-spelling-grammar-mistakes-correct-usage-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2e0ade7c-4dbb-4361-897c-99e824f211ea/age-based-gift-recommendation-guide-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/c3eafc03-3529-465c-b883-eb329b1cb992/gangnam-blind-date-spot-recommendations-dark-lighting",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0e2f5daa-2625-4df5-9371-c0672c1be7d0/datadog-trace-error-analysis-duplo-github-code-investigation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/18914f11-cf41-44c3-bc5f-2062cd6e1d68/efficient-jira-usage-guide-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/da81f096-a38c-478e-a7e1-79b8bdc9cd81/aws-waf-monthly-security-report-sample-creation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e1ea7324-636c-4d38-a467-e8839a1250b8/context-pattern-programming-state-management-oop-benefits",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8423a6ec-c054-4673-a05b-d62c24bd0409/quantum-computing-investment-analysis-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5a4ff883-7697-455e-8e0b-676e4c444e94/korea-newlywed-housing-support-policies-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/262102d0-3539-4f69-96f5-830a1828b33d/ankle-sprain-first-aid-rice-method-treatment",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cbd326db-a6d6-42b3-a933-4bda32032770/mcp-guardian-security-framework-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a3c4e234-865b-4f57-b8b3-7a0084f91d37/korean-youtube-comedy-channel-recommendations-for-depression",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/79f55ebe-417b-433c-b0cb-a44cba107e8c/schedule-meeting-with-jane-tuesday-afternoon",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a87d01b3-79d0-4383-a93a-4aada192728b/schedule-meeting-with-regan-querypie",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a5402faf-0f10-4bba-a0cf-1cbbc0366ca7/convenience-store-delivery-prices-by-weight",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e408ed14-c910-45f2-8ce5-b1eb5e738c70/5-billion-won-apartments-gyeonggi-couples-school-districts-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/809768c6-1043-40cd-bc3c-c1195f7c04aa/command-pattern-vs-task-pattern-typescript-explanation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5c8b9aa0-fbab-4f4e-96d6-fd030a70dba7/eating-exercise-tips-preventing-diabetes",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b626f7c3-8959-46c9-83d6-e3f3af0acf92/soslab-stock-analysis-and-chinese-lidar-competition",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/06eeb3fe-43cc-46ff-866c-d7a75bd00ad5/react-hooks-vs-class-components-comparison",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f39d3ed9-19b3-4ad7-9c05-0e1eb031c1d2/achilles-tendinitis-early-treatment-prevention-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5a36e465-3f99-4f06-985d-0e2c06d00842/dog-dangerous-foods-korean-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a5dcd2f2-cb43-4299-a883-d3f67fb65292/korean-zero-trust-security-model-explanation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6a7168b7-fffc-4056-93ef-54a46ee6abab/kubernetes-authentication-authorization-methods-practice-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d9a1764c-907a-48eb-a8e8-bf693797b0bc/cloud-security-discussion-korean-best-practices-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4b812e33-a41a-49b7-a8a3-74c6353d3115/korean-personality-test-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e3c662c9-7bdf-4846-b84f-b60f15cb1e6f/data-management-facet-vs-tag-and-abac-implementation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4cbe8990-2af9-4498-ad72-8093c42b0982/clean-architecture-book-summary-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bdb34288-1298-45fe-8454-b990be6417e2/korean-greeting-and-schedule-assistant-introduction",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/17cbfaf0-9198-464c-8f0f-ae524c3dfd9d/magok-station-restaurant-discount-events-inquiry",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2c2866ba-2c4d-463e-bce1-fdcc5949f65d/airline-baggage-regulations-korea",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/89cdb380-c962-4135-b154-9d7c7fa4c3e9/javascript-async-await-error-handling-best-practices",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/114ad6b7-cd6d-4892-8730-ba072b841ddb/korean-isa-pension-fund-irp-comparison-office-worker-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/361d75a7-bc26-47e3-9daa-267176b55d60/simple-aglio-olio-recipe-with-cost-calculation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e9b87fe4-baf3-46a4-9820-51e7edd60790/aws-vpc-design-best-practices-investigation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b3560262-ec0b-45e0-ad36-60950d0d794d/generator-ui-agnostic-domain-modeling-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ad97cca8-327d-4ab6-aeba-e393ecb28597/korean-domestic-activity-travel-destinations-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/13cedc80-440d-44aa-accc-d5af423de4f8/qa-engineer-certifications-guide-istqb-cste-cmsq-casq-testing-qualifications",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/98395955-1326-4639-a4f7-3066561f2825/subway-route-magok-to-seongsu-schedule-transfer-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/812a6064-4ede-4295-afb0-e6e6dc4ab9d3/top-10-jobs-disappearing-by-2025-automation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fee56a21-3f1c-4fd4-9caf-616d0210a4dd/cooper-dating-advice-commandments",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4dc2cb2b-4e79-4da4-b387-9802467d9b4e/korean-english-vocabulary-quiz-10-questions",
+              "last_crawled": "Jan 15, 2026"
+            }
+          ]
+        },
+        "Blocked by robots.txt": {
+          "total": 9,
+          "collected": 9,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/ebe24a8f-8b8b-48bc-b163-a8caa60fc6b7/mcp-server-local-testing-setup-tutorial",
+              "last_crawled": "Oct 10, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9f29d5aa-7bcb-4bba-91b9-25e6be9d2cd0/how-to-clear-cache-browsers-devices",
+              "last_crawled": "Oct 8, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3172073e-dd1b-43c1-ab9f-0d77abd54d50/automate-daily-ai-news-morning-briefing-setup",
+              "last_crawled": "Oct 4, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5b31355a-391a-4b9b-a3d1-c5dd9a1b502c/how-to-take-screenshots-on-windows",
+              "last_crawled": "Sep 30, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/83f9dce1-a066-442e-a93b-791fd5a904c7/usd-to-krw-exchange-rate-query",
+              "last_crawled": "Sep 29, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7d5d1ffc-7c0e-410f-b4c6-f38e319028da/mens-hairstyle-consultation-for-wide-forehead-long-face",
+              "last_crawled": "Aug 25, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a998af7f-2e7a-417f-b82d-129ea3713e70/korean-conversation-about-ohtani-shohei-baseball-player-details",
+              "last_crawled": "Aug 25, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/api/data",
+              "last_crawled": "Aug 23, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/__manifest",
+              "last_crawled": "Aug 14, 2025"
+            }
+          ]
+        },
+        "Crawled - currently not indexed": {
+          "total": 13,
+          "collected": 13,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/3d2cf7f8-8dc4-40a8-b54e-1f764103159a/seoul-bingsu-restaurant-recommendations-top-10-hot-spots",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/38b293c4-7006-466b-b07d-affb018161bd/korean-flirting-speech-styles-dos-and-donts",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b0dabe6-13f1-4792-b4b0-4bb04729ea37/korea-post-office-registered-mail-parcel-pricing-guide",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/52983c23-c60f-4d9f-9f95-299f27c9fc80/kpop-demon-hunters-american-reaction-discussion",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa91b26e-cae7-4efa-a807-d47ca1210952/2025-birth-support-policies-seoul-seongdong-district-government-benefits",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/34329dfa-f85b-4a35-9004-ca8982bcc438/budget-student-steak-recipe-recommendations-korean",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/20adecf3-1151-478d-a172-14969c4430b3/photoshop-alternative-image-editing-programs-recommendation",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/97ac23e3-33cd-4506-a74c-cec3dc0dbf0f/ancient-cacio-e-pepe-recipe-history-shepherds",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b384577-dec6-4743-9d3e-fd8f4fb9fad5/korean-queen-mindset-edgy-book-recommendations",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/login",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3a83c644-42da-4957-b865-63ad3f475dda/what-is-artificial-intelligence-ai-explanation",
+              "last_crawled": "Sep 4, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/513ba9f6-27ad-48d4-847a-ee9b124fa048/best-stocks-invest-2026-recommendations-analyst-predictions",
+              "last_crawled": "Aug 21, 2025"
+            }
+          ]
+        },
+        "Duplicate, Google chose different canonical than user": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/92ba7897-2d22-4f48-af0a-d4cb9fda8c56/workplace-harassment-reporting-procedures-evidence-collection",
+              "last_crawled": "Feb 3, 2026"
+            }
+          ]
+        },
+        "Discovered - currently not indexed": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/44870b2d-ee13-4750-998b-8fc9ee767a33/fiber-concept-and-react-fiber-implementation",
+              "last_crawled": "N/A"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/reports/data/gsc-detail-aip-docs-2026-02-06.json
+++ b/reports/data/gsc-detail-aip-docs-2026-02-06.json
@@ -1,0 +1,256 @@
+{
+  "generated_at": "2026-02-06T18:04:49.328263",
+  "sites": [
+    {
+      "label": "aip-docs.app.querypie.com",
+      "reasons": {
+        "Page with redirect": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://aip-docs.app.querypie.com/user-guide",
+              "last_crawled": "Feb 2, 2026"
+            }
+          ]
+        },
+        "Crawled - currently not indexed": {
+          "total": 25,
+          "collected": 25,
+          "urls": [
+            {
+              "url": "https://aip-docs.app.querypie.com/user-guide/chat",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/daum-search",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/code-executor",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/datadog",
+              "last_crawled": "Jan 17, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/github",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/redis",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/discord",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/google-sheets",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-oracle",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/kubernetes",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/querypie-client",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-mssql",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/salesforce",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/naver-search",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-mariadb",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/n8n-chat-trigger-node",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/supabase",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-clickhouse",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/querypie-sac",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/querypie-dac",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/atlassian-jira",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/_next/static/css/e32f16046da0f225.css?dpl=dpl_6Q6wepHswSidF6jQLeaM2ZpSGc96",
+              "last_crawled": "Oct 26, 2025"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/_next/static/css/59ed3440722801e9.css?dpl=dpl_922e7dxHKBMJ2W2jGrkae5jCTbJk",
+              "last_crawled": "Oct 16, 2025"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/favicon.ico",
+              "last_crawled": "Sep 17, 2025"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/_next/static/css/59ed3440722801e9.css?dpl=dpl_WvF7jvGHgDAJxS4nfUgZArSYRU6H",
+              "last_crawled": "Sep 14, 2025"
+            }
+          ]
+        },
+        "Duplicate without user-selected canonical": {
+          "total": 22,
+          "collected": 22,
+          "urls": [
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/chat",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide",
+              "last_crawled": "Feb 2, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/terminal-sandbox",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/sequentialthinking",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/google-drive",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-snowflake",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/release-notes",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/airtable",
+              "last_crawled": "Jan 20, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/hubspot",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/google-gmail",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/querypie-dac-admin",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/admin-guide/billing",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/quickstart",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/special-features/edge-tunnel",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/jdbc-postgresql",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/special-features/remote-preset-mcp",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/automation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/admin-guide/mcp-management",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/dify-api-access",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/faq",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/user-guide/mcps/ssh",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/en/admin-guide/knowledge-management",
+              "last_crawled": "Jan 14, 2026"
+            }
+          ]
+        },
+        "Not found (404)": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://aip-docs.app.querypie.com/user-guide/special-features",
+              "last_crawled": "Nov 3, 2025"
+            }
+          ]
+        },
+        "Discovered - currently not indexed": {
+          "total": 5,
+          "collected": 5,
+          "urls": [
+            {
+              "url": "https://aip-docs.app.querypie.com/en",
+              "last_crawled": "N/A"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/ja",
+              "last_crawled": "N/A"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/ja/user-guide/special-features/custom-mcp",
+              "last_crawled": "N/A"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/ja/user-guide/special-features/smart-tool-discovery",
+              "last_crawled": "N/A"
+            },
+            {
+              "url": "https://aip-docs.app.querypie.com/ko",
+              "last_crawled": "N/A"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/reports/data/gsc-detail-app-2026-02-06.json
+++ b/reports/data/gsc-detail-app-2026-02-06.json
@@ -1,0 +1,716 @@
+{
+  "generated_at": "2026-02-06T18:06:13.646200",
+  "sites": [
+    {
+      "label": "app.querypie.com",
+      "reasons": {
+        "Duplicate without user-selected canonical": {
+          "total": 145,
+          "collected": 145,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/b8dc27ab-d8dd-41ae-ab3d-c2256cb10eb8/chuncheon-1night-2day-travel-recommendation",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b20d3be7-3c3c-43a8-9947-466905f74c65/2025-fall-mens-fashion-coordination-trends",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/395635db-2fa8-4255-934d-b9085f19c5d4/it-worker-wrist-protection-exercises-equipment-guide",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bdbd52bb-2a2a-43a5-9b59-42ee0b363972/cryptocurrency-top10-daily-chart-analysis-bitcoin-ethereum",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cda0a024-8bc4-4e2c-b7ec-ae0d9135b400/youtube-premium-value-analysis-korean-pricing",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/825ef2cd-ae1f-4ee4-b4b5-15d6b7a94b89/korean-mens-fall-hair-style-guide-barber-request-tips",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fab857c8-2b6c-4c26-bee5-aa15e5d1076c/anyang-gunpo-uiwang-dating-spots-dim-lighting-restaurants",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/33b90907-b8f4-4199-91e8-211b984a127d/korean-couples-travel-destinations-public-transport-guide",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/abb5cba9-dbe5-48a5-906b-77fd01ab7cab/qa-terminology-list-korean-100-terms-explanation",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/abf9b2fe-0c79-469b-8885-944b63ca80c0/30-dae-saengil-seonmul-kakaotalk-seonmul-10-seon-gagyeok-chucheeon",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2f363124-beaa-4318-8d64-87443215c960/hongdae-escape-room-cafe-horror-themes-booking-times",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/36e122d6-3925-44be-8628-c8fdda62e283/kbo-team-selection-guide-for-beginners",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/49ec61d6-49fe-4f3d-be94-f6814ff0fa61/korean-saju-birth-time-estimation-using-past-events",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa273e70-baf1-4966-9e08-355982df8bc8/s3-bucket-policy-examples",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b2a81f7-a02d-40aa-b032-a45dc320e420/react-gof-design-patterns-examples",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2fa6d3dd-a6e8-4b35-a84c-ce7c1b7d728b/2025-korean-foreign-hiphop-trends-drake-future-popularity-discussion",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b49e7825-977b-4555-80d9-9c2af9bd2765/korean-instagram-photo-poses-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ec09669b-7521-4f06-a4ed-10fe9a640241/gwangmyeong-market-restaurant-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5732b25a-3014-4b99-b19b-9e8a6e364c8e/2026-korean-real-estate-market-forecast-prediction",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6549b671-0d4f-4eec-b403-3d4c87b2d8cb/boys-2-planet-top-9-winner-predictions-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/80c689e9-1db9-41ec-8d5c-a476f2770b81/qa-engineer-effective-report-writing-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cfa7690f-0d60-4a01-9e30-ad8b149aa442/schedule-meeting-with-jane-project-discussion-tuesday-nov-19-2pm",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e7d437d2-df53-4d73-bd96-8232d0a3268c/schedule-meeting-with-jane-wednesday",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0223a74c-0a57-414c-b57c-783e832ea1da/italian-pastrami-mortadella-sandwich-recipe-korea-shopping",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3671ea81-ac26-4abd-a931-dc40fac57a6e/apartment-dog-breed-recommendations-owner-personality-match",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3ee7c3e0-ee3b-47c9-85c2-896658ef3b36/best-places-to-visit-europe-travel-destinations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6ecda236-384e-4263-be46-dcd69d7c19ed/2025-3q-4q-movie-releases-korean-list-rating-table-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/26327be9-abe2-424b-88e5-4a8b1153f6b5/gangwondo-beach-recommendations-for-kids-swimming",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7e012e59-088b-4b07-be63-1dc4d33d5750/korean-music-recommendations-dopamine-songs-trending-kpop-hits-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f47fef57-0d1a-4d52-926d-9ce6d94f5f70/30s-employee-government-benefits-calendar-registration",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/98832e3f-e8bf-4a4b-a8e5-5af08b445eb0/hello-world-greeting",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9a1fa878-149c-4eb7-803d-e55c1b3aac23/korean-40s-health-self-care-program-for-office-workers",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/efb947cc-81d8-494a-9fa3-b670b0c2eeea/quantum-computers-bitcoin-encryption-threat-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8d005ec0-13c6-428f-9287-46ede82d34c7/qa-test-automation-tools-detailed-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ef9c7c5a-d923-408d-b79a-fc28a362a4df/korean-real-estate-investment-analysis-2025-apartment-market-forecast",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/23ccc5a3-008e-44a9-be45-7a6589158b07/wedding-guest-hair-makeup-ramada-sindorim-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/53cb4d0f-d4a9-4ba3-847b-bd69daec8a7d/how-to-invest-in-cryptocurrency-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9e58f90d-20a0-4741-9b61-1c05777c8d50/css-modern-features-learning-2025-beyond-css3",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5047a919-6311-4dd9-b4c6-f9248144d585/powell-august-fed-speech-september-rate-cut-market-sentiment-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8bcb7aea-489a-41ac-938b-c066dda8c119/coinness-bitcoin-ethereum-price-news-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/77dbd04d-993f-44ee-901f-036f46897ee0/parcel-hub-fraud-pattern-analysis-report",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d1e837c9-3401-4bf2-90dd-fe55a046e2f3/m7-magnificent-seven-stocks-analysis-investment-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/03b6b743-d337-4065-9976-bac466252209/bitcoin-investment-analysis-2025-price-forecast-macroeconomic-factors",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/984be0b4-3de0-4ede-949f-8875e74e96cc/korean-dermatology-treatment-recommendations-and-gangnam-clinic-events",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b72a5b0d-16cb-4133-afb7-2b792688c65b/4-week-plan-to-reduce-child-smartphone-screen-time-gradually",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/49c45100-1a31-4408-a3a1-6bb6c021fd2d/korean-oliveyoung-cosmetics-recommendation-with-pricing",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9c63757a-260c-4a9b-8b08-6401c2380977/quick-mbti-test-5-questions-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e919b4d0-39f4-43d1-8827-8023a16a20ef/best-budget-accommodations-tokyo-under-50-dollars-per-night",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0b212a83-f402-472f-add1-aa5e026d1666/san-francisco-weather-today-61f-partly-cloudy",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3c14c673-f1ff-4f80-ad2f-9ff519559972/world-top-10-travel-destinations-complete-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/32e16ae5-4bb6-4bcd-8106-ebe7245d6bef/finding-cheap-flights-tips-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d011d8d6-d842-4550-8611-39c42d2d384e/bluehands-search-bongcheon-dong-area",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e8cd8db8-3ae5-4727-85bf-6144080ecd55/chatgpt-latest-features-and-prompt-templates-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ecd9a808-d85b-40a9-8edd-ec8cecb5cfce/ai-era-talent-skills-technical-human-capabilities-job-market",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/95ebd3c6-b508-4b83-aa4a-174565007cf5/seoul-2025-q3-events-exhibitions-concerts-performances-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/65d85402-2f91-4dd3-9cf8-6a42c03b961f/2025-latest-kpop-dance-challenge-rankings-popularity",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/54b755e6-20a9-4fdf-97ec-f82ab1e3f18f/workplace-communication-methods-korean-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6d301136-0803-4808-b42b-72cf0c6da95d/how-to-lose-weight-fast-safely-evidence-based-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bfcb6ad6-3cf0-4c2a-94dd-829e149152fb/son-heung-min-mls-lafc-transfer-fee-salary-summary",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6c1fb6e5-141a-4c1e-848a-1cdd462aaf5a/creating-information-security-pledge-for-development-company",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/dc700168-d5ca-415b-9c11-fc90a0104716/graphic-design-reference-site-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cca77015-6466-4a7d-b398-568cf96cb2e5/kubernetes-k8s-basic-commands-kubectl-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e67b01a3-80b6-49b4-84d2-a9b91375423a/tylenol-acetaminophen-drug-interactions-contraindications",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/91b2ac1d-d0f9-4d9b-8fc6-555ef5c268ab/qa-testing-preparation-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/21652f0f-62a6-4e24-87b4-00b848e15914/office-worker-perfume-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5ba59bb2-977b-423c-85d6-3bbafb92103f/ashley-queens-recipe-tips-korean-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3649550f-ff00-424e-abd2-68a737340f2a/2025-5th-mirae-house-application-conditions-requirements",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4bdc1b8c-7225-4603-be66-d75e929ec969/korean-office-worker-business-manners-etiquette-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/80470600-55b9-46fa-a4b9-d169042ca456/kube-prometheus-stack-operator-rbac-cluster-permissions-security",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2b45d859-fedb-486c-bed5-de37936ab336/guide-to-better-sleep-hygiene-tips",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d5ddd8d2-2157-4f5b-8efe-4831be1f9cc4/coinbase-stock-investment-analysis-revenue-competition-bitcoin-volatility",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/1c6ed7be-b360-4a3f-b3cc-5b110d1805c1/hypertension-friendly-foods-korean-diet-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d80663e8-9477-40a1-a878-9b28d0228310/son-heung-min-style-changes-epl-to-mls-adaptation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/575fa631-e785-46e1-8de2-509495d1e951/research-zai-and-chatzai-compared-with-querypie-ai",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b542ff36-c1dd-461c-9eb1-5e3f29e64599/long-term-stock-investment-plan-for-child-born-2025-monthly-savings-strategy",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/24f86db4-525e-41d8-b366-1df31d6c1423/latest-ai-technology-trends-and-business-applications-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e6e2bd32-7f7d-4230-a70d-630049b3bdc9/shinbashi-yakitori-restaurant-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/23e781bb-0329-4e86-9d3f-fd59e0c476b0/suwon-dongtan-blind-date-romantic-venues-recommendation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/af436981-eebd-46de-b2e9-7c2056500b81/seoul-housing-support-policy-for-elderly-over-65-homeless-couples",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/06ae88d4-ea15-40ab-9d8c-e7c859ba9802/korean-ideal-type-personality-analysis-q-and-a",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fc27b752-0d76-4e68-b072-da005ee72127/korean-recipe-recommendations-with-available-ingredients",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4e543638-04be-4aed-8095-9974e08810c5/yeongdeungpo-market-restaurant-recommendations-honest-reviews",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d37f28be-2ed6-4347-adc8-572e4fba29ae/ai-era-automation-resistant-jobs-analysis-future-career-trends",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f56df22e-eca5-4496-afb6-d24782a07f10/cryptocurrency-stocks-coinbase-bitcoin-mining-investing-basics-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/711fbd9d-cbd3-4d32-9364-0f658786b0f5/korean-gold-price-inquiry-today",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/616e686b-ce72-41d8-b485-fda6f13432d9/new-york-vs-los-angeles-5-day-vacation-comparison",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/462c12e1-3962-4350-a536-0db5571208a5/travel-luggage-size-recommendations-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d3d589fd-082e-4f47-b635-863966e9a6ef/ankle-sprain-cold-hot-compress-treatment-advice",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7ee2df9d-9fe5-4b6c-b7d7-c6d19401e786/korean-fortune-telling-birth-chart-analysis-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/1351729a-ea37-4666-b4e3-05b247f9179a/san-francisco-weather-lookup-and-forecast",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2889eed3-0f02-437c-ac00-ae5f2f2cffaa/nintendo-2025-upcoming-games-list-korean-request",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3daa6132-c8be-44b0-adaa-dfc2e5e876ff/monitoring-tools-comparison-prometheus-vs-datadog-vs-newrelic",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f23432c0-244f-4df0-af82-c88bd37f1f9f/marriage-registration-disadvantages-and-loan-issues",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f6c5655a-1011-4522-8153-2e7f5c097570/korean-twenty-questions-guessing-hint-game",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa828aea-10ce-4516-8fad-be64d51c6c51/personal-color-consultation-deep-autumn-diagnosis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/335b8b75-6eb4-4711-8d91-98589b42559b/seoul-weather-forecast-partly-cloudy-17-celsius",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8d2b9c3a-1dd9-4b43-a60e-7e31a50d2622/bitcoin-market-cap-vs-gold-surpass-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a7c795df-7791-49dc-941b-79fd5d0df5fd/korean-user-requests-weather-forecasts-for-seoul-and-san-francisco-with-hourly-tables",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8276d11e-d2fe-4fc5-967c-1c03e6e8d17e/best-passive-income-ideas-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bd129b59-5ac2-4872-bbf7-4b08e958f848/busan-2-nights-3-days-winter-travel-plan-budget-100k-won-daily",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f62ccb30-0239-4949-8cb6-3febe748e160/budget-overseas-travel-destinations-korea-cost-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/34385240-8e1d-47ab-b768-ea457a331682/traditional-italian-carbonara-recipe-no-cream",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/96911063-59f3-4035-912a-f2d7405af3e0/tsa-liquid-restrictions-airplane-travel",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/35d00962-05f4-418f-ab9a-cf5bd57e5f25/korean-spelling-grammar-mistakes-correct-usage-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2e0ade7c-4dbb-4361-897c-99e824f211ea/age-based-gift-recommendation-guide-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/c3eafc03-3529-465c-b883-eb329b1cb992/gangnam-blind-date-spot-recommendations-dark-lighting",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/0e2f5daa-2625-4df5-9371-c0672c1be7d0/datadog-trace-error-analysis-duplo-github-code-investigation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/18914f11-cf41-44c3-bc5f-2062cd6e1d68/efficient-jira-usage-guide-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/da81f096-a38c-478e-a7e1-79b8bdc9cd81/aws-waf-monthly-security-report-sample-creation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e1ea7324-636c-4d38-a467-e8839a1250b8/context-pattern-programming-state-management-oop-benefits",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/8423a6ec-c054-4673-a05b-d62c24bd0409/quantum-computing-investment-analysis-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5a4ff883-7697-455e-8e0b-676e4c444e94/korea-newlywed-housing-support-policies-2025",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/262102d0-3539-4f69-96f5-830a1828b33d/ankle-sprain-first-aid-rice-method-treatment",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/cbd326db-a6d6-42b3-a933-4bda32032770/mcp-guardian-security-framework-analysis",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a3c4e234-865b-4f57-b8b3-7a0084f91d37/korean-youtube-comedy-channel-recommendations-for-depression",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/79f55ebe-417b-433c-b0cb-a44cba107e8c/schedule-meeting-with-jane-tuesday-afternoon",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a87d01b3-79d0-4383-a93a-4aada192728b/schedule-meeting-with-regan-querypie",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a5402faf-0f10-4bba-a0cf-1cbbc0366ca7/convenience-store-delivery-prices-by-weight",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e408ed14-c910-45f2-8ce5-b1eb5e738c70/5-billion-won-apartments-gyeonggi-couples-school-districts-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/809768c6-1043-40cd-bc3c-c1195f7c04aa/command-pattern-vs-task-pattern-typescript-explanation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5c8b9aa0-fbab-4f4e-96d6-fd030a70dba7/eating-exercise-tips-preventing-diabetes",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b626f7c3-8959-46c9-83d6-e3f3af0acf92/soslab-stock-analysis-and-chinese-lidar-competition",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/06eeb3fe-43cc-46ff-866c-d7a75bd00ad5/react-hooks-vs-class-components-comparison",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/f39d3ed9-19b3-4ad7-9c05-0e1eb031c1d2/achilles-tendinitis-early-treatment-prevention-strategies",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5a36e465-3f99-4f06-985d-0e2c06d00842/dog-dangerous-foods-korean-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a5dcd2f2-cb43-4299-a883-d3f67fb65292/korean-zero-trust-security-model-explanation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6a7168b7-fffc-4056-93ef-54a46ee6abab/kubernetes-authentication-authorization-methods-practice-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/d9a1764c-907a-48eb-a8e8-bf693797b0bc/cloud-security-discussion-korean-best-practices-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4b812e33-a41a-49b7-a8a3-74c6353d3115/korean-personality-test-conversation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e3c662c9-7bdf-4846-b84f-b60f15cb1e6f/data-management-facet-vs-tag-and-abac-implementation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4cbe8990-2af9-4498-ad72-8093c42b0982/clean-architecture-book-summary-korean",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/bdb34288-1298-45fe-8454-b990be6417e2/korean-greeting-and-schedule-assistant-introduction",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/17cbfaf0-9198-464c-8f0f-ae524c3dfd9d/magok-station-restaurant-discount-events-inquiry",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/2c2866ba-2c4d-463e-bce1-fdcc5949f65d/airline-baggage-regulations-korea",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/89cdb380-c962-4135-b154-9d7c7fa4c3e9/javascript-async-await-error-handling-best-practices",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/114ad6b7-cd6d-4892-8730-ba072b841ddb/korean-isa-pension-fund-irp-comparison-office-worker-recommendations",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/361d75a7-bc26-47e3-9daa-267176b55d60/simple-aglio-olio-recipe-with-cost-calculation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/e9b87fe4-baf3-46a4-9820-51e7edd60790/aws-vpc-design-best-practices-investigation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/b3560262-ec0b-45e0-ad36-60950d0d794d/generator-ui-agnostic-domain-modeling-discussion",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/ad97cca8-327d-4ab6-aeba-e393ecb28597/korean-domestic-activity-travel-destinations-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/13cedc80-440d-44aa-accc-d5af423de4f8/qa-engineer-certifications-guide-istqb-cste-cmsq-casq-testing-qualifications",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/98395955-1326-4639-a4f7-3066561f2825/subway-route-magok-to-seongsu-schedule-transfer-guide",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/812a6064-4ede-4295-afb0-e6e6dc4ab9d3/top-10-jobs-disappearing-by-2025-automation",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/fee56a21-3f1c-4fd4-9caf-616d0210a4dd/cooper-dating-advice-commandments",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/4dc2cb2b-4e79-4da4-b387-9802467d9b4e/korean-english-vocabulary-quiz-10-questions",
+              "last_crawled": "Jan 15, 2026"
+            }
+          ]
+        },
+        "Blocked by robots.txt": {
+          "total": 9,
+          "collected": 9,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/ebe24a8f-8b8b-48bc-b163-a8caa60fc6b7/mcp-server-local-testing-setup-tutorial",
+              "last_crawled": "Oct 10, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/9f29d5aa-7bcb-4bba-91b9-25e6be9d2cd0/how-to-clear-cache-browsers-devices",
+              "last_crawled": "Oct 8, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3172073e-dd1b-43c1-ab9f-0d77abd54d50/automate-daily-ai-news-morning-briefing-setup",
+              "last_crawled": "Oct 4, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/5b31355a-391a-4b9b-a3d1-c5dd9a1b502c/how-to-take-screenshots-on-windows",
+              "last_crawled": "Sep 30, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/83f9dce1-a066-442e-a93b-791fd5a904c7/usd-to-krw-exchange-rate-query",
+              "last_crawled": "Sep 29, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/7d5d1ffc-7c0e-410f-b4c6-f38e319028da/mens-hairstyle-consultation-for-wide-forehead-long-face",
+              "last_crawled": "Aug 25, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/a998af7f-2e7a-417f-b82d-129ea3713e70/korean-conversation-about-ohtani-shohei-baseball-player-details",
+              "last_crawled": "Aug 25, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/api/data",
+              "last_crawled": "Aug 23, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/__manifest",
+              "last_crawled": "Aug 14, 2025"
+            }
+          ]
+        },
+        "Crawled - currently not indexed": {
+          "total": 13,
+          "collected": 13,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/3d2cf7f8-8dc4-40a8-b54e-1f764103159a/seoul-bingsu-restaurant-recommendations-top-10-hot-spots",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/38b293c4-7006-466b-b07d-affb018161bd/korean-flirting-speech-styles-dos-and-donts",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b0dabe6-13f1-4792-b4b0-4bb04729ea37/korea-post-office-registered-mail-parcel-pricing-guide",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/52983c23-c60f-4d9f-9f95-299f27c9fc80/kpop-demon-hunters-american-reaction-discussion",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/aa91b26e-cae7-4efa-a807-d47ca1210952/2025-birth-support-policies-seoul-seongdong-district-government-benefits",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/34329dfa-f85b-4a35-9004-ca8982bcc438/budget-student-steak-recipe-recommendations-korean",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/20adecf3-1151-478d-a172-14969c4430b3/photoshop-alternative-image-editing-programs-recommendation",
+              "last_crawled": "Feb 4, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/97ac23e3-33cd-4506-a74c-cec3dc0dbf0f/ancient-cacio-e-pepe-recipe-history-shepherds",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/6b384577-dec6-4743-9d3e-fd8f4fb9fad5/korean-queen-mindset-edgy-book-recommendations",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/login",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/3a83c644-42da-4957-b865-63ad3f475dda/what-is-artificial-intelligence-ai-explanation",
+              "last_crawled": "Sep 4, 2025"
+            },
+            {
+              "url": "https://app.querypie.com/chat/publication/513ba9f6-27ad-48d4-847a-ee9b124fa048/best-stocks-invest-2026-recommendations-analyst-predictions",
+              "last_crawled": "Aug 21, 2025"
+            }
+          ]
+        },
+        "Duplicate, Google chose different canonical than user": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/92ba7897-2d22-4f48-af0a-d4cb9fda8c56/workplace-harassment-reporting-procedures-evidence-collection",
+              "last_crawled": "Feb 3, 2026"
+            }
+          ]
+        },
+        "Discovered - currently not indexed": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://app.querypie.com/chat/publication/44870b2d-ee13-4750-998b-8fc9ee767a33/fiber-concept-and-react-fiber-implementation",
+              "last_crawled": "N/A"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/reports/data/gsc-detail-docs-2026-02-06.json
+++ b/reports/data/gsc-detail-docs-2026-02-06.json
@@ -1,0 +1,2706 @@
+{
+  "generated_at": "2026-02-06T18:03:26.673091",
+  "sites": [
+    {
+      "label": "docs.querypie.com",
+      "reasons": {
+        "Not found (404)": {
+          "total": 215,
+          "collected": 215,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/license-installation",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/prerequisites/linux-distribution-and-docker-podman-support-status",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/kubernetes-logs/api-reference/11.4.1/v2",
+              "last_crawled": "Feb 2, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/kubernetes-logs/api-reference/11.4.1/v0.9",
+              "last_crawled": "Feb 2, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/general/system/integrations/identity-providers/aws-sso-saml-20",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/kubernetes/api-reference/11.4.1/v0.9",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/kubernetes/api-reference/11.4.1/v2",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/installation",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/prerequisites/configuring-rootless-mode-with-podman",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/installation/installation/querypie/mysql/",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/databases/connection-management/cloud-providers/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/995_external.json",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/server-configuration-requirements",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation/querypie-acp-community-edition/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/user-manual/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/general/user-management/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/general/user-management/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 28, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/overview/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 28, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/overview/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 28, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/querypie-acp-community-edition",
+              "last_crawled": "Jan 28, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/general/user-management/provisioning/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/app/script/migrate.sh",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/container-environment-variables/optimizing-dbmaxconnectionsize",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/multi-agent/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/system/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/databases/monitoring/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/web-apps/wac-quickstart/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/web-apps/wac-quickstart/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/audit/server-logs/session-monitoring",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/home/ec2-user/querypie/11.1.1/systemd/podman-querypie-database.service",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/home/ec2-user/querypie/current/systemd/podman-querypie-database.service",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/installation/prerequisites/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/installation/prerequisites/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/database-access-control/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/database-access-control/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 22, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/installation/installation/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 22, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/workflow/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 22, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/workflow/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 20, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/databases/ledger-management/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 19, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/audit/server-logs/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 18, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/audit/server-logs/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 18, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/user-manual/database-access-control/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 17, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/user-manual/database-access-control/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 17, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/release-notes/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/databases/monitoring/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/server-logs/session-monitoring",
+              "last_crawled": "Jan 14, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/databases/ledger-management/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 13, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/server-access-control/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 13, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_5kSwYFmrwjEkNCgTu1rZc2KPJvrT",
+              "last_crawled": "Jan 12, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/user-manual/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 12, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/servers/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-overview/installation-and-customer-support",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/server-logs/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/server-access-control/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/server-logs/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/kubernetes/k8s-access-control/access-control/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 9, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 9, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs/session-monitoring",
+              "last_crawled": "Jan 7, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/kubernetes/k8s-access-control/policies/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 6, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/querypie-overview/installation-and-customer-support",
+              "last_crawled": "Jan 5, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/web-app-logs/api-reference/11.4.1/v0.9",
+              "last_crawled": "Jan 5, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/web-app-logs/api-reference/11.4.1/v2",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/prerequisites/linux-distribution-and-docker-podman-support-status",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-overview/installation-and-customer-support",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/querypie-overview/installation-and-customer-support",
+              "last_crawled": "Dec 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/server-configuration-requirements/server-configuration-requirements-summary",
+              "last_crawled": "Dec 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support",
+              "last_crawled": "Dec 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_5U7heFdVmwhe5RQXaATvjVSHxJNS",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/v2/dac/connections/{dbConnectionUuid}",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/container-environment-variables/querypieweburl",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/mcp",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_3GDvAtXpni2t22pF1W4DXNuijTui",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/server-configuration-requirements/public-cloud-production-server-requirements",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/v2/users",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/installation/installing-on-aws-eks",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/server-configuration-requirements",
+              "last_crawled": "Dec 11, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/system-architecture-and-network-access-control",
+              "last_crawled": "Dec 11, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/installation/comparison-of-setupsh-and-setupv2sh",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/license-installation",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/container-environment-variables",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/installation",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/installation/installation-guide-simple-configuration",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/prerequisites/configuring-rootless-mode-with-podman",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/server-configuration-requirements/on-premise-vm-requirements",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/prerequisites",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/saml/login",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/saml/sp/metadata",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/installation/installation-guide-setupv2sh",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation-and-customer-support/querypie-acp-community-edition",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/VERYSILENT",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/Url=",
+              "last_crawled": "Nov 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/Port=",
+              "last_crawled": "Nov 23, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/secret-store",
+              "last_crawled": "Nov 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/resources/learn/tutorials/*",
+              "last_crawled": "Nov 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.14.0/sql",
+              "last_crawled": "Nov 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-33",
+              "last_crawled": "Nov 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.14.0/dm",
+              "last_crawled": "Nov 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-14-0-9-14-2",
+              "last_crawled": "Nov 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-18",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-7",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-17",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-8",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/server-access-request",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-38",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-12-0-9-12-13",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-41",
+              "last_crawled": "Nov 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-26",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-34",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-4",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-29",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-23",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-4",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/system-auth-logs",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-15-0-9-15-2",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-2",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-2",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-5",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/aws",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/okta",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/sql",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/external-api-9-9-4-9-9-5",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-6",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-1",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-3",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/aws-db",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/ip",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-access-request",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-37",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-20",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-21",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-15",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/for-agent/server-agent/download",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/ldap",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-5",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/release-notes",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-35",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-13",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-30",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/export-request",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-31",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/database-proxy",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-39",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-9-0-9-9-8",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/slack-dm",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-32",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-14",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-19",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-16-0",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/workflow",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/customer-portal",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/alerts/workflow-new-request",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/resources/discover/blog",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/gcp",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/querypie-overview",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-3",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-24",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-36",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-25",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-12",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/azure",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/slack-dm-workflow",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-22",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-11-0-9-11-5",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/resources/discover/webinars",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/resources/learn/tutorials",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/database-settings/policies/sensitive-data",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/module/orders/*",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/database-settings/policies/data-access",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/database-settings/policies/data-masking",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/&",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/$",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-8-0-9-8-10",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/mongodb",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-11",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-9",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/9-12-0",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-16",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/sql-sql-request",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/db-1",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/sso",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/admin/*",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/general-settings/*",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/data",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/alerts/unusual-login-attempt",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/alerts/sql-execution",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/cloud-providers/{cloudProviderUuid}",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/New",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/994_external.json",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/alerts/prevented-sql-execution",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/audit-logs/{uuid}",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/audit-logs/{id}",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/roles/{roleUuid}",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/notifications",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/connection-auth-logs",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/audit-logs",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/general-settings/user-management/*",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/saml/sp/acs",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/roles",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/connections",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/kubernetes-settings/*",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/approval-rules",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/cloud-providers",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/general-settings/user-management",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/release-notes/990-998/9810_external.json",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/connections/{uuid}",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/general-settings",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/kubernetes-settings",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api/external/alerts/db-connection-attempt",
+              "last_crawled": "Nov 3, 2025"
+            }
+          ]
+        },
+        "Blocked by robots.txt": {
+          "total": 24,
+          "collected": 24,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/de05190b6eab4be0.js?dpl=dpl_GDMKGCfjLLkeViQnLhSsJVVZXwGs",
+              "last_crawled": "Feb 1, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/a66e3feff4794f99.js?dpl=dpl_5ySK7pxQeivsFtihGP3R9QECzLdw",
+              "last_crawled": "Jan 31, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/api/og/ko/installation/querypie-acp-community-edition/mcp-configuration-guide",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/0358bc85a0d0d081.js?dpl=dpl_8cg3qs47MqSvY1b1uzGA9ciJok5J",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/ad0c35c0a364a359.js?dpl=dpl_GDMKGCfjLLkeViQnLhSsJVVZXwGs",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/ad0c35c0a364a359.js?dpl=dpl_8cg3qs47MqSvY1b1uzGA9ciJok5J",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/73e3194f06db260e.js?dpl=dpl_8cg3qs47MqSvY1b1uzGA9ciJok5J",
+              "last_crawled": "Jan 28, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_B4V1sbwqkMrTEmuf6fDsc2mfcesF",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_5kSwYFmrwjEkNCgTu1rZc2KPJvrT",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/d96012bcfc98706a.js?dpl=dpl_GDMKGCfjLLkeViQnLhSsJVVZXwGs",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/9d8f07c5d155fb66.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/95087ad89f6582e3.css?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/0496c9fd17b4b6c1.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/a28c02955ef6c0fc.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/915ca11d2136d143.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_2KJHGWn6A5g9SRsePWyhSmXqv7sV",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/31a4f8c49cfd872a.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/d2be314c3ece3fbe.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/ff1a16fafef87110.js?dpl=dpl_5Jn9w1NUr35JLPgTV9HBYzx4v18b",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/chunks/0358bc85a0d0d081.js?dpl=dpl_GDMKGCfjLLkeViQnLhSsJVVZXwGs",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_2KJHGWn6A5g9SRsePWyhSmXqv7sV",
+              "last_crawled": "Jan 21, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_9MobEzCGFhXa4eepcQWdhUhCDNZx",
+              "last_crawled": "Jan 16, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_JEGAcdCTC8ETPq9FCmiGbB49YkdG",
+              "last_crawled": "Jan 13, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_JEGAcdCTC8ETPq9FCmiGbB49YkdG",
+              "last_crawled": "Jan 13, 2026"
+            }
+          ]
+        },
+        "Page with redirect": {
+          "total": 219,
+          "collected": 219,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/release-notes",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9180-9183",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/990-998/external-api-changes-994-version-995-version",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9120-91214/menu-improvement-guide-9120",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/user-manual/workflow/requesting-sql/",
+              "last_crawled": "Jan 27, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/user-agent",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/installation/server-configuration-requirements/server-configuration-requirements-summary",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/overview",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/overview/",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/querypie-overview",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-overview/proxy-management",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/overview/proxy-management",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/en/overview/",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart/root-ca-certificate-installation-guide",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/-1",
+              "last_crawled": "Jan 15, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow",
+              "last_crawled": "Jan 9, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/server-access-control/using-web-terminal",
+              "last_crawled": "Jan 5, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/users",
+              "last_crawled": "Jan 5, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/",
+              "last_crawled": "Jan 5, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/access-control",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/users/password-change-enforcement-and-account-deletion-feature-for-qp-admin-default-account",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/multi-agent/multi-agent-3rd-party-tool-support-list-by-os",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/security",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/multi-agent/multi-agent-seamless-ssh-usage-guide",
+              "last_crawled": "Jan 4, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/querypie-overview/system-architecture-overview",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-restricted-data-access",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/access-control-logs",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1150",
+              "last_crawled": "Dec 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/kubernetes-logs/pod-session-recordings",
+              "last_crawled": "Dec 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation/querypie-acp-community-edition/mcp-configuration-guide",
+              "last_crawled": "Dec 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/roles",
+              "last_crawled": "Dec 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/maintenance",
+              "last_crawled": "Dec 23, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/reports/reports",
+              "last_crawled": "Dec 22, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/installation/installation/installation-guide-setupv2sh",
+              "last_crawled": "Dec 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-sql-export",
+              "last_crawled": "Dec 20, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-account-management/password-provisioning/creating-password-change-job",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9120-91214",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-google-cloud-api-for-oauth-20",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/profile-editor/custom-attribute",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1110-1112",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/web-app-logs/web-event-audit",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-email",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/dac-general-configurations/unmasking-zones",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/reports/audit-log-export",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/authentication/setting-up-multi-factor-authentication",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/allowed-zones",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/alerts",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart/1030-wac-jit-permission-acquisition-guide",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-server-access",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/profile-editor",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/identity-providers/integrating-with-aws-sso-saml-20",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/kubernetes-access-control",
+              "last_crawled": "Dec 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/db-connections/aws-athena-specific-guide",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/db-connections",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/general",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/web-access-control",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/980-9812",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/my-dashboard/user-password-reset-via-email",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/policies/policy-exception",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/sac-general-configurations",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-ui-code-helper-guide",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/connection-management",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/users/user-profile",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/roles/setting-kubernetes-roles",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/new-policy-management",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/ssh-configurations",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/new-policy-management/exception-management",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9110-9115",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1100",
+              "last_crawled": "Dec 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/cloud-providers",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-google-cloud",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/authentication/integrating-with-google-saml",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/kubernetes-logs",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/authentication/integrating-with-ldap",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/authentication/integrating-with-okta",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-permissions",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/ledger-management/ledger-table-policy",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-unmasking-mask-removal-request",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/multi-agent/multi-agent-linux-installation-and-usage-guide",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/provisioning/activating-provisioning",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-server-privilege",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/server-access-control",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-slack-dm",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/web-app-access-control/policies",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/policies",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/web-access-control/accessing-web-applications-websites",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1130",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/connection-management/web-apps",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-account-management/password-provisioning",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart/initial-wac-setup-in-web-app-configurations",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-account-management/server-account-templates",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-db-policy-exception",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/command-templates",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/policy-exception-logs",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/new-policy-management/data-paths",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/kerberos-configurations",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/dml-snapshots",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/access-control",
+              "last_crawled": "Dec 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/connection-management/clusters",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs/account-lock-history",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/web-app-access-control/access-control",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/kubernetes-logs/request-audit",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/monitoring/proxy-management",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-azure",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/web-app-logs/web-access-history",
+              "last_crawled": "Dec 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/policies",
+              "last_crawled": "Dec 11, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/groups",
+              "last_crawled": "Dec 11, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers",
+              "last_crawled": "Dec 11, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart/wac-troubleshooting-guide",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/policies/enabling-server-proxy",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/access-control/granting-and-revoking-kubernetes-roles",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs/server-role-history",
+              "last_crawled": "Dec 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/channels",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/connection-management",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/db-access-history",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/web-app-logs/jit-access-control-logs",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs/session-logs",
+              "last_crawled": "Dec 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/workflow-management/all-requests",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-aws",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/general-logs",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/connection-management/cloud-providers/synchronizing-kubernetes-resources-from-aws",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/provisioning/okta-provisioning-integration-guide",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/990-998/external-api-changes-9810-version-994-version",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/jobs",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/authentication",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management/roles",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-splunk",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/policies/data-masking",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-action-configuration-reference-guide",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-event-callback",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/new-policy-management/data-policies",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/connection-management/web-app-configurations",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/identity-providers",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/company-management/licenses",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/wac-quickstart",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/cloud-providers/synchronizing-db-resources-from-ms-azure",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/workflow-management/workflow-configurations",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/web-app-logs",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/database-access-control",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/connection-management/cloud-providers",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/account-lock-history",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/general-logs/workflow-logs",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/user-management",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/approval-additional-features-proxy-approval-resubmission-etc",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control",
+              "last_crawled": "Dec 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/monitoring",
+              "last_crawled": "Dec 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification",
+              "last_crawled": "Dec 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/connection-management/cloud-providers",
+              "last_crawled": "Dec 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/querypie-manual/10.2.0/-101",
+              "last_crawled": "Dec 1, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/servers",
+              "last_crawled": "Nov 30, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.2.0/user-agent",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/dac-general-configurations",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/my-dashboard",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/integrations/integrating-with-secret-store",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/workflow/requesting-sql",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1030-1034",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/web-app-logs/web-app-role-history",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/roles",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/dac-general-configurations/masking-pattern-menu-relocated",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-tips-guide",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/database-logs/running-queries",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/server-access-control/policies/setting-server-access-policy",
+              "last_crawled": "Nov 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/workflow-management/approval-rules",
+              "last_crawled": "Nov 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/proxyjump-configurations",
+              "last_crawled": "Nov 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel",
+              "last_crawled": "Nov 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/querypie-overview/proxy-management/enable-database-proxy",
+              "last_crawled": "Nov 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/reports",
+              "last_crawled": "Nov 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/kubernetes/kac-general-configurations",
+              "last_crawled": "Nov 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/web-apps/web-app-access-control/roles",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/server-groups/managing-servers-as-groups",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/server-groups",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/servers/connection-management/cloud-providers/synchronizing-server-resources-from-aws",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9100-9104",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/preferences",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/user-manual/kubernetes-access-control/checking-access-permission-list",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/1140",
+              "last_crawled": "Nov 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/policies-1",
+              "last_crawled": "Nov 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9140-9143",
+              "last_crawled": "Nov 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9170-9171",
+              "last_crawled": "Nov 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/slack-dm-workflow",
+              "last_crawled": "Nov 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual",
+              "last_crawled": "Nov 13, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/release-notes",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/multi-agent-limitations",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/kubernetes-logs/kubernetes-role-history",
+              "last_crawled": "Nov 10, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/policies/sensitive-data",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/all-requests",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/release-notes/9190",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/databases/policies/masking-pattern",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/general/system/api-token",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit/server-logs/server-access-history",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie/9.16.0/-10",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.3.0/web-app-configurations-wac",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.2.0",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.2.0/",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/workflow/requesting-sql/",
+              "last_crawled": "Nov 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/server-roles",
+              "last_crawled": "Nov 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.2.0/google-saml-integration",
+              "last_crawled": "Nov 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/11.0.0/db-connections",
+              "last_crawled": "Nov 1, 2025"
+            }
+          ]
+        },
+        "Duplicate without user-selected canonical": {
+          "total": 19,
+          "collected": 19,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/servers",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers",
+              "last_crawled": "Nov 12, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/release-notes",
+              "last_crawled": "Nov 3, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/general/workflow-management",
+              "last_crawled": "Nov 1, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/kubernetes/k8s-access-control/access-control",
+              "last_crawled": "Oct 31, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/server-logs/server-role-history",
+              "last_crawled": "Oct 31, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/connection-management/kerberos-configurations",
+              "last_crawled": "Oct 31, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/database-logs/access-control-logs",
+              "last_crawled": "Oct 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/new-policy-management/data-paths",
+              "last_crawled": "Oct 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/policies/data-access",
+              "last_crawled": "Oct 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/servers/server-access-control/policies",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/workflow/requesting-db-access",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-access-control/access-control/granting-and-revoking-roles",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-access-control",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/connection-management/cloud-providers/verifying-cloud-synchronization-settings-with-dry-run-feature",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/release-notes/990-998/external-api-changes-994-version-995-version",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/ledger-management/ledger-approval-rules",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/user-management",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-account-management/ssh-key-configurations",
+              "last_crawled": "Oct 25, 2025"
+            }
+          ]
+        },
+        "Alternate page with proper canonical tag": {
+          "total": 1,
+          "collected": 1,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/",
+              "last_crawled": "Dec 16, 2025"
+            }
+          ]
+        },
+        "Crawled - currently not indexed": {
+          "total": 159,
+          "collected": 159,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/ja/installation/installation/comparison-of-setupsh-and-setupv2sh",
+              "last_crawled": "Feb 3, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/release-notes/1000-1002",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/workflow/requesting-server-access",
+              "last_crawled": "Jan 30, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/connection-management/server-agents-for-rdp",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/web-apps/web-app-access-control/access-control/granting-and-revoking-roles",
+              "last_crawled": "Jan 29, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/favicon.ico?favicon.adafc105.ico",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/connection-management/db-connections/google-bigquery-oauth-authentication-configuration",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-db-through-reverse-tunnel",
+              "last_crawled": "Jan 26, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/web-apps/wac-quickstart/1027-wac-role-policy-guide",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/system/integrations/integrating-with-email",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/user-management/authentication",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/installation/installation/installation-guide-simple-configuration",
+              "last_crawled": "Jan 25, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/audit/database-logs/access-control-logs",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/web-app-logs/web-event-audit",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/system/integrations/integrating-with-slack-dm/slack-dm-workflow-notification-types",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/system/api-token",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-servers-through-reverse-tunnel",
+              "last_crawled": "Jan 24, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-account-management/account-management",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/connection-management/db-connections/documentdb-specific-guide",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/kubernetes/connection-management/clusters/manually-registering-kubernetes-clusters",
+              "last_crawled": "Jan 23, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/installation/installation/installing-on-aws-eks",
+              "last_crawled": "Jan 22, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/administrator-manual/servers/server-access-control",
+              "last_crawled": "Jan 21, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/workflow/requesting-server-privilege",
+              "last_crawled": "Jan 20, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/user-management/profile-editor",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/ledger-management/ledger-table-policy",
+              "last_crawled": "Jan 10, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_DYJHy9n2tyAbZJtQsZrHEtF6jt3o",
+              "last_crawled": "Jan 7, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/workflow-management",
+              "last_crawled": "Jan 6, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_DYJHy9n2tyAbZJtQsZrHEtF6jt3o",
+              "last_crawled": "Jan 3, 2026"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/my-dashboard",
+              "last_crawled": "Dec 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/api-reference",
+              "last_crawled": "Dec 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/favicon.ico",
+              "last_crawled": "Dec 20, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/connection-management/cloud-providers",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_7FDCNuaBJKvnHoXYBR8Le5Hq4iqF",
+              "last_crawled": "Dec 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_E5Lor2RvLm1cAfQKYXkPRGkL2rhS",
+              "last_crawled": "Dec 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_E5Lor2RvLm1cAfQKYXkPRGkL2rhS",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_7FDCNuaBJKvnHoXYBR8Le5Hq4iqF",
+              "last_crawled": "Dec 17, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_Ckb3LuwWZJ36uyZGQdpPMZh8Avsq",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_Ckb3LuwWZJ36uyZGQdpPMZh8Avsq",
+              "last_crawled": "Dec 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_94iifqtawXUZVTV8U3Y62patAwer",
+              "last_crawled": "Dec 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_iggeHjikd12WAmpybUhkySFmk6ub",
+              "last_crawled": "Dec 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/11c59cc40cabfed8.css?dpl=dpl_94iifqtawXUZVTV8U3Y62patAwer",
+              "last_crawled": "Dec 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_FA4PGLsyZRS6fe6fmBP5DyYub3QH",
+              "last_crawled": "Dec 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/2d82b615fcca1590.css?dpl=dpl_8qBZBvQeFmWXsFDsubHtnxPMZbXW",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/administrator-manual/audit",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/general/company-management/alerts/new-request-template-variables-by-request-type",
+              "last_crawled": "Nov 30, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/workflow",
+              "last_crawled": "Nov 30, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/connection-management/servers/manually-registering-individual-servers",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/web-app-logs/user-activity-recordings",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/database-logs/policy-audit-logs",
+              "last_crawled": "Nov 29, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_Eg6Ax7TfmLET7YxfZ7H4151cMhZA",
+              "last_crawled": "Nov 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_Eg6Ax7TfmLET7YxfZ7H4151cMhZA",
+              "last_crawled": "Nov 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_BeovTgVYdc3CHJ12RJkmwWQ9CpNJ",
+              "last_crawled": "Nov 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_28G9wnPTaSwf4KviEoUQuq4aAZQ8",
+              "last_crawled": "Nov 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_EHRJ4RVu5gHj7JcCso1BsKQt3hGR",
+              "last_crawled": "Nov 22, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/connection-management/proxyjump-configurations",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_ASUNDKYpo6NZMrvPqFUn19p94VZJ",
+              "last_crawled": "Nov 20, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_EHRJ4RVu5gHj7JcCso1BsKQt3hGR",
+              "last_crawled": "Nov 19, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_GtY1rBPKjB5fWgPronsCP2rsx3ma",
+              "last_crawled": "Nov 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_ASUNDKYpo6NZMrvPqFUn19p94VZJ",
+              "last_crawled": "Nov 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_GtY1rBPKjB5fWgPronsCP2rsx3ma",
+              "last_crawled": "Nov 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_3GDvAtXpni2t22pF1W4DXNuijTui",
+              "last_crawled": "Nov 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_7KzMzwrLEnPXDmSR4AZG8394d7gQ",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_84tAaJPwLUywE1P4FZpAgPvVjpFD",
+              "last_crawled": "Nov 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_HanPKwPJ5o93nN3cWr1cUp9pfNzU",
+              "last_crawled": "Nov 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/064e7bae1d4bb9b0.css?dpl=dpl_HanPKwPJ5o93nN3cWr1cUp9pfNzU",
+              "last_crawled": "Nov 6, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/_next/static/css/372f8dcde2d2dafb.css?dpl=dpl_7KzMzwrLEnPXDmSR4AZG8394d7gQ",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/favicon.ico?29988679ddf1846a",
+              "last_crawled": "Nov 5, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/release-notes/1100",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/release-notes/1010-10111",
+              "last_crawled": "Oct 25, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/kerberos-configurations",
+              "last_crawled": "Oct 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/-15",
+              "last_crawled": "Sep 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/channels",
+              "last_crawled": "Sep 16, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie/9.16.0/",
+              "last_crawled": "Sep 2, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/external-api-9-9-4-9-9-5",
+              "last_crawled": "Jun 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/account-lock-history",
+              "last_crawled": "May 15, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/user-management",
+              "last_crawled": "May 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/cloud-providers",
+              "last_crawled": "May 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/db-access-control-1",
+              "last_crawled": "Apr 28, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/audit-log-export",
+              "last_crawled": "Apr 27, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/command-audit",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/secret-store",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/-47",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/role-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/9-14-0-9-14-3",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/okta-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/db-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/ssh-key",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/api",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/aws",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/roles",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/admin-role-history",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/external-api-9-10-0",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/request-audit",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/db-5",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/-13",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/aws-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/kubernetes-access-control",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/allowed-zones",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/-11",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/-41",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/database-proxy",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/9-12-0-9-12-14",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.18.0/-39",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.1.0/masking-pattern",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/connection-management",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/secret-store-1",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/-5",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.11.0/-21",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.11.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/ledger-approval-rules",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.18.0/tmaxtibero",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/database-proxy",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.11.0/-2",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/blocked-accounts",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/-19",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/9-12-0-9-12-11",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/db-access-request",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/-6",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/--",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie/9.16.0",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/cloud-providers",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/default-privilege",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/dml-snapshots",
+              "last_crawled": "Apr 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/okta",
+              "last_crawled": "Apr 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/server-access-request",
+              "last_crawled": "Apr 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/access-control-1",
+              "last_crawled": "Mar 26, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/cloud-providers-1",
+              "last_crawled": "Mar 23, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.20.0/db-access-request",
+              "last_crawled": "Mar 18, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/9-18-0-9-18-3",
+              "last_crawled": "Feb 14, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/9-12-0-9-12-14",
+              "last_crawled": "Feb 9, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/data-masking",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/splunk",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/company-management",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/aws-db",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.18.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.18.0/-34",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/job",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/sql",
+              "last_crawled": "Feb 8, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/dml-snapshots",
+              "last_crawled": "Feb 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/-14",
+              "last_crawled": "Feb 7, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.16.0/-10",
+              "last_crawled": "Oct 30, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.1.0/9-8-0-9-8-12",
+              "last_crawled": "Oct 10, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/database-proxy",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.12.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.18.0/9-14-0-9-14-3",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.15.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.14.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/-10",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/-40",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.19.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 12, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/en/querypie-manual/10.0.0/blocked-accounts",
+              "last_crawled": "Sep 4, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 4, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie/9.17.0/-42",
+              "last_crawled": "Sep 4, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/external-api-9-8-10-9-9-4",
+              "last_crawled": "Sep 3, 2024"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/querypie-manual/10.0.0/9-8-0-9-8-12",
+              "last_crawled": "Sep 3, 2024"
+            }
+          ]
+        },
+        "Duplicate, Google chose different canonical than user": {
+          "total": 23,
+          "collected": 23,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/container-environment-variables",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/server-configuration-requirements/server-configuration-requirements-summary",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/installation/installing-on-aws-eks",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/installation/installation-guide-simple-configuration",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/container-environment-variables/querypieweburl",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/system-architecture-and-network-access-control",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/installation/installation-guide-setupv2sh",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/prerequisites",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/server-configuration-requirements/on-premise-vm-requirements",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/server-configuration-requirements/public-cloud-production-server-requirements",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/installation/comparison-of-setupsh-and-setupv2sh",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ko/installation-and-customer-support/container-environment-variables/optimizing-dbmaxconnectionsize",
+              "last_crawled": "Dec 4, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/general/user-management/provisioning",
+              "last_crawled": "Nov 24, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/general-logs/reverse-tunnels/communicating-with-clusters-through-reverse-tunnel",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/kubernetes/k8s-access-control/policies/kubernetes-policy-yaml-code-syntax-guide",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-access-control/blocked-accounts",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/reports",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/audit/kubernetes-logs/kubernetes-role-history",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/servers/server-account-management",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/administrator-manual/databases/connection-management/db-connections/custom-data-source-configuration-and-log-verification",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/ja/user-manual/database-access-control/connecting-to-custom-data-source",
+              "last_crawled": "Nov 21, 2025"
+            },
+            {
+              "url": "https://docs.querypie.com/en/administrator-manual/servers/server-account-management/ssh-key-configurations",
+              "last_crawled": "Nov 13, 2025"
+            }
+          ]
+        },
+        "Discovered - currently not indexed": {
+          "total": 2,
+          "collected": 2,
+          "urls": [
+            {
+              "url": "https://docs.querypie.com/en/installation/product-versions",
+              "last_crawled": "N/A"
+            },
+            {
+              "url": "https://docs.querypie.com/en/overview/proxy-management/enable-database-proxy",
+              "last_crawled": "N/A"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/reports/data/gsc-index-2026-02-06.json
+++ b/reports/data/gsc-index-2026-02-06.json
@@ -1,0 +1,225 @@
+{
+  "sites": [
+    {
+      "site_url": "https://www.querypie.com/",
+      "label": "www.querypie.com",
+      "reasons": [
+        {
+          "reason": "Page with redirect",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 1227
+        },
+        {
+          "reason": "Not found (404)",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 822
+        },
+        {
+          "reason": "Alternate page with proper canonical tag",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 197
+        },
+        {
+          "reason": "Crawled - currently not indexed",
+          "source": "Google systems",
+          "validation": "Failed",
+          "pages": 96
+        },
+        {
+          "reason": "Redirect error",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 18
+        },
+        {
+          "reason": "Blocked by robots.txt",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 18
+        },
+        {
+          "reason": "Soft 404",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 1
+        },
+        {
+          "reason": "Duplicate, Google chose different canonical than user",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 25
+        },
+        {
+          "reason": "Duplicate without user-selected canonical",
+          "source": "Website",
+          "validation": "Passed",
+          "pages": 18
+        },
+        {
+          "reason": "Server error (5xx)",
+          "source": "Website",
+          "validation": "N/A",
+          "pages": 0
+        },
+        {
+          "reason": "Discovered - currently not indexed",
+          "source": "Google systems",
+          "validation": "Passed",
+          "pages": 144
+        }
+      ],
+      "scraped_at": "2026-02-06T23:04:19.036267"
+    },
+    {
+      "site_url": "https://docs.querypie.com/",
+      "label": "docs.querypie.com",
+      "reasons": [
+        {
+          "reason": "Not found (404)",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 215
+        },
+        {
+          "reason": "Blocked by robots.txt",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 24
+        },
+        {
+          "reason": "Page with redirect",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 219
+        },
+        {
+          "reason": "Duplicate without user-selected canonical",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 19
+        },
+        {
+          "reason": "Alternate page with proper canonical tag",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 1
+        },
+        {
+          "reason": "Crawled - currently not indexed",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 159
+        },
+        {
+          "reason": "Duplicate, Google chose different canonical than user",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 23
+        },
+        {
+          "reason": "Redirect error",
+          "source": "Website",
+          "validation": "Passed",
+          "pages": 0
+        },
+        {
+          "reason": "Discovered - currently not indexed",
+          "source": "Google systems",
+          "validation": "Passed",
+          "pages": 2
+        }
+      ],
+      "scraped_at": "2026-02-06T23:04:25.541722"
+    },
+    {
+      "site_url": "https://aip-docs.app.querypie.com/",
+      "label": "aip-docs.app.querypie.com",
+      "reasons": [
+        {
+          "reason": "Page with redirect",
+          "source": "Website",
+          "validation": "Failed",
+          "pages": 1
+        },
+        {
+          "reason": "Crawled - currently not indexed",
+          "source": "Google systems",
+          "validation": "Failed",
+          "pages": 25
+        },
+        {
+          "reason": "Duplicate without user-selected canonical",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 22
+        },
+        {
+          "reason": "Not found (404)",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 1
+        },
+        {
+          "reason": "Discovered - currently not indexed",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 5
+        }
+      ],
+      "scraped_at": "2026-02-06T23:04:31.352849"
+    },
+    {
+      "site_url": "https://app.querypie.com/",
+      "label": "app.querypie.com",
+      "reasons": [
+        {
+          "reason": "Duplicate without user-selected canonical",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 145
+        },
+        {
+          "reason": "Blocked by robots.txt",
+          "source": "Website",
+          "validation": "Started",
+          "pages": 9
+        },
+        {
+          "reason": "Crawled - currently not indexed",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 13
+        },
+        {
+          "reason": "Duplicate, Google chose different canonical than user",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 1
+        },
+        {
+          "reason": "Discovered - currently not indexed",
+          "source": "Google systems",
+          "validation": "Started",
+          "pages": 1
+        },
+        {
+          "reason": "Redirect error",
+          "source": "Website",
+          "validation": "Passed",
+          "pages": 0
+        },
+        {
+          "reason": "Soft 404",
+          "source": "Website",
+          "validation": "Passed",
+          "pages": 0
+        }
+      ],
+      "scraped_at": "2026-02-06T23:04:37.307821"
+    }
+  ],
+  "generated_at": "2026-02-06T23:04:11.414393"
+}

--- a/reports/gsc-index-report-2026-02-06.md
+++ b/reports/gsc-index-report-2026-02-06.md
@@ -1,0 +1,155 @@
+# GSC 인덱싱 상태 주간 리포트
+
+- 생성: 2026-02-06 23:05 (자동)
+
+## 전체 요약
+
+| 사이트 | 미인덱싱 페이지 |
+|--------|----------------|
+| www.querypie.com | 2566 |
+| docs.querypie.com | 662 |
+| aip-docs.app.querypie.com | 54 |
+| app.querypie.com | 169 |
+| **합계** | **3451** |
+
+## 사이트별 상세
+
+### www.querypie.com
+
+| Reason | Pages | Source | Validation |
+|--------|-------|--------|------------|
+| Page with redirect | 1227 | Website | Failed |
+| Not found (404) | 822 | Website | Failed |
+| Alternate page with proper canonical tag | 197 | Website | Failed |
+| Crawled - currently not indexed | 96 | Google systems | Failed |
+| Redirect error | 18 | Website | Started |
+| Blocked by robots.txt | 18 | Website | Started |
+| Soft 404 | 1 | Website | Started |
+| Duplicate, Google chose different canonical than user | 25 | Google systems | Started |
+| Duplicate without user-selected canonical | 18 | Website | Passed |
+| Server error (5xx) | 0 | Website | N/A |
+| Discovered - currently not indexed | 144 | Google systems | Passed |
+
+**권장 조치:**
+- Page with redirect: 리다이렉트 체인 정리, 사이트맵에서 최종 URL만 포함
+- Not found (404): 301 리다이렉트 설정 또는 사이트맵에서 제거
+- Alternate page with proper canonical tag: 확인 필요: GSC에서 상세 내용 직접 확인
+- Crawled - currently not indexed: 콘텐츠 품질 개선, 내부 링크 보강, thin content 제거
+- Redirect error: 확인 필요: GSC에서 상세 내용 직접 확인
+- Blocked by robots.txt: robots.txt 규칙 검토, 필요한 페이지 허용
+- Soft 404: 실제 콘텐츠 추가 또는 적절한 404 응답 반환
+- Duplicate, Google chose different canonical than user: canonical 태그와 실제 콘텐츠 일치 확인, 중복 콘텐츠 정리
+- Duplicate without user-selected canonical: canonical 태그 설정 또는 중복 페이지 통합
+- Server error (5xx): 서버 오류 원인 파악 및 수정, 서버 안정성 확인
+- Discovered - currently not indexed: 사이트맵 제출 확인, 크롤 예산 최적화, 불필요 URL 정리
+
+### docs.querypie.com
+
+| Reason | Pages | Source | Validation |
+|--------|-------|--------|------------|
+| Not found (404) | 215 | Website | Failed |
+| Blocked by robots.txt | 24 | Website | Failed |
+| Page with redirect | 219 | Website | Started |
+| Duplicate without user-selected canonical | 19 | Website | Started |
+| Alternate page with proper canonical tag | 1 | Website | Started |
+| Crawled - currently not indexed | 159 | Google systems | Started |
+| Duplicate, Google chose different canonical than user | 23 | Google systems | Started |
+| Redirect error | 0 | Website | Passed |
+| Discovered - currently not indexed | 2 | Google systems | Passed |
+
+**권장 조치:**
+- Not found (404): 301 리다이렉트 설정 또는 사이트맵에서 제거
+- Blocked by robots.txt: robots.txt 규칙 검토, 필요한 페이지 허용
+- Page with redirect: 리다이렉트 체인 정리, 사이트맵에서 최종 URL만 포함
+- Duplicate without user-selected canonical: canonical 태그 설정 또는 중복 페이지 통합
+- Alternate page with proper canonical tag: 확인 필요: GSC에서 상세 내용 직접 확인
+- Crawled - currently not indexed: 콘텐츠 품질 개선, 내부 링크 보강, thin content 제거
+- Duplicate, Google chose different canonical than user: canonical 태그와 실제 콘텐츠 일치 확인, 중복 콘텐츠 정리
+- Redirect error: 확인 필요: GSC에서 상세 내용 직접 확인
+- Discovered - currently not indexed: 사이트맵 제출 확인, 크롤 예산 최적화, 불필요 URL 정리
+
+### aip-docs.app.querypie.com
+
+| Reason | Pages | Source | Validation |
+|--------|-------|--------|------------|
+| Page with redirect | 1 | Website | Failed |
+| Crawled - currently not indexed | 25 | Google systems | Failed |
+| Duplicate without user-selected canonical | 22 | Website | Started |
+| Not found (404) | 1 | Website | Started |
+| Discovered - currently not indexed | 5 | Google systems | Started |
+
+**권장 조치:**
+- Page with redirect: 리다이렉트 체인 정리, 사이트맵에서 최종 URL만 포함
+- Crawled - currently not indexed: 콘텐츠 품질 개선, 내부 링크 보강, thin content 제거
+- Duplicate without user-selected canonical: canonical 태그 설정 또는 중복 페이지 통합
+- Not found (404): 301 리다이렉트 설정 또는 사이트맵에서 제거
+- Discovered - currently not indexed: 사이트맵 제출 확인, 크롤 예산 최적화, 불필요 URL 정리
+
+### app.querypie.com
+
+| Reason | Pages | Source | Validation |
+|--------|-------|--------|------------|
+| Duplicate without user-selected canonical | 145 | Website | Started |
+| Blocked by robots.txt | 9 | Website | Started |
+| Crawled - currently not indexed | 13 | Google systems | Started |
+| Duplicate, Google chose different canonical than user | 1 | Google systems | Started |
+| Discovered - currently not indexed | 1 | Google systems | Started |
+| Redirect error | 0 | Website | Passed |
+| Soft 404 | 0 | Website | Passed |
+
+**권장 조치:**
+- Duplicate without user-selected canonical: canonical 태그 설정 또는 중복 페이지 통합
+- Blocked by robots.txt: robots.txt 규칙 검토, 필요한 페이지 허용
+- Crawled - currently not indexed: 콘텐츠 품질 개선, 내부 링크 보강, thin content 제거
+- Duplicate, Google chose different canonical than user: canonical 태그와 실제 콘텐츠 일치 확인, 중복 콘텐츠 정리
+- Discovered - currently not indexed: 사이트맵 제출 확인, 크롤 예산 최적화, 불필요 URL 정리
+- Redirect error: 확인 필요: GSC에서 상세 내용 직접 확인
+- Soft 404: 실제 콘텐츠 추가 또는 적절한 404 응답 반환
+
+## Sitemap 등록 현황
+
+### www.querypie.com
+
+| Sitemap | Type | Submitted | Last read | Status | Pages |
+|---------|------|-----------|-----------|--------|------:|
+| /rss-ko-learn.xml | RSS | Jan 25, 2026 | Feb 4, 2026 | Success | 33 |
+| /rss-en-learn.xml | RSS | Jan 25, 2026 | Feb 4, 2026 | Success | 54 |
+| /sitemap.xml | Sitemap | Jan 25, 2026 | Feb 4, 2026 | 1 error | 167 |
+| /aip/sitemap/publication-1.xml | Sitemap | Jan 24, 2026 | Jan 29, 2026 | Success | 156 |
+| /docs/sitemap.xml | Sitemap | Jan 19, 2026 | Feb 2, 2026 | Success | 247 |
+| /aip/sitemap.xml | Sitemap index | Jan 14, 2026 | Feb 4, 2026 | Success | 156 |
+| /wiki/sitemap.xml | Sitemap | Oct 27, 2025 | Feb 5, 2026 | Success | 305 |
+| /rss-ja-learn.xml | RSS | Apr 2, 2025 | Jan 30, 2026 | Success | 54 |
+| /rss-ja-webinar.xml | RSS | Apr 2, 2025 | Feb 5, 2026 | Success | 19 |
+| /rss-ja-blog.xml | RSS | Apr 2, 2025 | Jan 31, 2026 | Success | 44 |
+| /rss-ko-webinar.xml | RSS | Apr 2, 2025 | Feb 5, 2026 | Success | 12 |
+| /rss-ko-blog.xml | RSS | Apr 2, 2025 | Jan 8, 2026 | Success | 43 |
+| /rss-en-webinar.xml | RSS | Apr 2, 2025 | Jan 19, 2026 | Success | 16 |
+| /rss-en-blog.xml | RSS | Apr 2, 2025 | Feb 6, 2026 | Success | 49 |
+
+**주의:** 오류가 있는 sitemap이 있습니다. GSC에서 상세 내용을 확인하세요.
+
+### docs.querypie.com
+
+| Sitemap | Type | Submitted | Last read | Status | Pages |
+|---------|------|-----------|-----------|--------|------:|
+| /ja/sitemap.xml | Sitemap | Dec 15, 2025 | Feb 4, 2026 | Success | 288 |
+| /ko/sitemap.xml | Sitemap | Dec 15, 2025 | Feb 3, 2026 | Success | 288 |
+| /en/sitemap.xml | Sitemap | Dec 15, 2025 | Feb 6, 2026 | Success | 289 |
+| /sitemap.xml | Sitemap index | Oct 24, 2025 | Oct 24, 2025 | Success | 864 |
+
+### aip-docs.app.querypie.com
+
+| Sitemap | Type | Submitted | Last read | Status | Pages |
+|---------|------|-----------|-----------|--------|------:|
+| /ja/sitemap.xml | Sitemap | Jan 25, 2026 | Feb 1, 2026 | Success | 83 |
+| /ko/sitemap.xml | Sitemap | Jan 25, 2026 | Feb 1, 2026 | Success | 82 |
+| /en/sitemap.xml | Sitemap | Jan 25, 2026 | Feb 1, 2026 | Success | 82 |
+| /sitemap.xml | Sitemap index | Nov 28, 2025 | Jan 30, 2026 | Success | 247 |
+
+### app.querypie.com
+
+| Sitemap | Type | Submitted | Last read | Status | Pages |
+|---------|------|-----------|-----------|--------|------:|
+| /sitemap/publication-1.xml | Sitemap | Jan 14, 2026 | Jan 14, 2026 | Success | 156 |
+| /sitemap.xml | Sitemap index | Jan 14, 2026 | Jan 14, 2026 | Success | 156 |

--- a/reports/gsc-indexing-improvement-summary.md
+++ b/reports/gsc-indexing-improvement-summary.md
@@ -1,0 +1,175 @@
+# GSC 인덱싱 개선 프로젝트 진행 요약
+
+- 최종 업데이트: 2026-02-07
+
+## 배경
+
+www.querypie.com 외 3개 사이트의 Google Search Console 인덱싱 상태를 분석하고,
+미인덱싱 URL을 체계적으로 해소하는 프로젝트입니다.
+
+## 현황 (2026-02-06 기준)
+
+| 사이트 | 미인덱싱 페이지 |
+|--------|---------------|
+| www.querypie.com | 2,566 |
+| docs.querypie.com | 662 |
+| aip-docs.app.querypie.com | 54 |
+| app.querypie.com | 169 |
+| **합계** | **3,451** |
+
+### www.querypie.com 미인덱싱 원인 분류
+
+| Reason | Pages |
+|--------|------:|
+| Page with redirect | 1,227 |
+| Not found (404) | 822 |
+| Alternate page with proper canonical tag | 197 |
+| Discovered - currently not indexed | 144 |
+| Crawled - currently not indexed | 96 |
+| Duplicate, Google chose different canonical | 25 |
+| Blocked by robots.txt | 18 |
+| Redirect error | 18 |
+| Duplicate without user-selected canonical | 18 |
+| Soft 404 | 1 |
+
+---
+
+## 완료된 작업
+
+### 분석 인프라 구축
+
+| PR | 내용 |
+|----|------|
+| skills-jk #62 | GSC 인덱싱 주간 점검 자동화 설계 |
+| skills-jk #63 | GSC 인덱싱 주간 리포트 자동화 구현 |
+| skills-jk #64~#65 | GSC 스크래핑 도구 (`bin/gsc-index-report`) 구현 |
+| skills-jk #67 | `--detail` / `--detail-reasons` 옵션 추가 (상세 URL 수집) |
+
+### 분석 리포트
+
+| PR | 내용 | 분석 대상 |
+|----|------|----------|
+| skills-jk #68 | www.querypie.com 404 URL 분석 | 822건 |
+| skills-jk #69 | www.querypie.com 리다이렉트/미인덱싱 분석 | 1,341건 |
+| skills-jk #70 | 4개 사이트 통합 분석 | 3,451건 |
+
+### 개선 구현 (corp-web-app)
+
+| PR | 내용 | 해소 건수 |
+|----|------|----------|
+| corp-web-app #580 | `/docs/*` sitemap 기반 301/307 리다이렉트 | ~700건 |
+| corp-web-app #581 | `/wiki/*` Confluence 리다이렉트 URL 오류 수정 + 301 전환 | ~171건 |
+
+### 개선 효과 요약
+
+| 항목 | 건수 |
+|------|------|
+| `/docs/*` 301 리다이렉트로 해소 | ~700 |
+| `/wiki/*` 301 리다이렉트 정상화로 해소 | ~171 |
+| **합계** | **~871건 (www 전체의 34%)** |
+
+---
+
+## 미완료 / 향후 계획
+
+### P1 — 즉시 실행 가능
+
+#### 1. robots.txt 정리 (corp-web-app)
+
+현재 robots.txt에 누락된 Disallow 규칙을 추가합니다.
+
+```
+Disallow: /wiki/
+Disallow: /_next/image
+Disallow: /chat/
+Disallow: /assets/api-docs.json
+```
+
+- 효과: 불필요 크롤 ~54건 차단 + 향후 크롤 방지
+- 작업량: 1 파일 수정
+
+#### 2. GSC sitemap 등록 정리 (GSC 콘솔 수동 작업)
+
+www.querypie.com GSC에 등록된 14개 sitemap 중 불필요한 항목을 제거합니다.
+
+| 제거 대상 | 등록 URL 수 | 사유 |
+|-----------|------------|------|
+| `/docs/sitemap.xml` | 247 | docs.querypie.com으로 이전 완료, `/docs/*`는 이제 301 리다이렉트 |
+| `/wiki/sitemap.xml` | 305 | Confluence 직접 연결, www에서 서빙할 필요 없음 |
+
+- 효과: ~550건의 불필요 크롤 해소
+- 작업: GSC 콘솔에서 수동 삭제
+
+### P2 — 조사 후 실행
+
+#### 3. `/resources/` 경로 리다이렉트 문제 (최대 잔여 카테고리)
+
+| 문제 유형 | 건수 |
+|-----------|------|
+| 404 | 418 |
+| Page with redirect | 342 |
+| Redirect error | 18 |
+| **소계** | **778** |
+
+- corp-web-app의 resources 라우팅 분석 필요
+- 리다이렉트 규칙 점검 및 사이트맵 정리
+
+#### 4. `/sitemap.xml` 오류 조사
+
+- GSC에서 www.querypie.com의 `/sitemap.xml`이 "1 error" 상태
+- 사이트맵 구조 및 내용 점검 필요
+
+#### 5. 프론트엔드 locale URL 버그 수정
+
+- `/jahttps://...` 패턴의 비정상 URL 생성 (10건)
+- locale prefix + 절대 URL 결합 로직 수정 필요
+
+### P3 — 중장기
+
+#### 6. docs.querypie.com 미인덱싱 해소 (662건)
+
+| 주요 원인 | 건수 |
+|-----------|------|
+| Page with redirect | 219 |
+| Not found (404) | 215 |
+| Crawled - currently not indexed | 159 |
+
+#### 7. app.querypie.com 중복 콘텐츠 정리 (169건)
+
+- Duplicate without user-selected canonical: 145건
+- canonical 태그 설정 필요
+
+#### 8. 주간 모니터링 체계 운영
+
+- `bin/gsc-index-report` 를 주간 실행하여 추이 추적
+- 개선 조치 후 효과 측정
+
+---
+
+## 관련 파일
+
+### 도구
+
+| 파일 | 설명 |
+|------|------|
+| `bin/gsc-index-report` | GSC 인덱싱 상태 스크래핑 + 리포트 생성 |
+| `bin/generate-docs-redirects` | docs 리다이렉트 맵 생성 (PR #71, open) |
+
+### 데이터
+
+| 파일 | 설명 |
+|------|------|
+| `reports/data/gsc-index-2026-02-06.json` | 4개 사이트 인덱싱 요약 데이터 |
+| `reports/data/gsc-detail-2026-02-06.json` | www.querypie.com 상세 URL 목록 |
+| `reports/data/gsc-detail-docs-2026-02-06.json` | docs.querypie.com 상세 URL 목록 |
+| `reports/data/gsc-detail-aip-docs-2026-02-06.json` | aip-docs.app.querypie.com 상세 URL 목록 |
+| `reports/data/gsc-detail-app-2026-02-06.json` | app.querypie.com 상세 URL 목록 |
+
+### 분석 리포트
+
+| 파일 | 설명 |
+|------|------|
+| `reports/gsc-index-report-2026-02-06.md` | 주간 인덱싱 상태 리포트 |
+| `reports/gsc-404-analysis-2026-02-06.md` | www 404 URL 분석 |
+| `reports/gsc-redirect-analysis-2026-02-06.md` | www 리다이렉트/미인덱싱 분석 |
+| `reports/gsc-all-sites-analysis-2026-02-06.md` | 4개 사이트 통합 분석 |


### PR DESCRIPTION
## Summary

GSC 인덱싱 개선 프로젝트의 진행 현황을 종합 정리하고, 수집된 상세 데이터를 백업합니다.

## 완료된 작업

### 분석 인프라 (skills-jk #62~#67)
- `bin/gsc-index-report`: GSC 인덱싱 상태 스크래핑 + 리포트 자동 생성
- `--detail` / `--detail-reasons`: 상세 URL 수집 기능

### 분석 리포트 (skills-jk #68~#70)
- www.querypie.com 404 URL 분석 (822건)
- www.querypie.com 리다이렉트/미인덱싱 분석 (1,341건)
- 4개 사이트 통합 분석 (3,451건)

### 개선 구현 (corp-web-app)
| PR | 내용 | 해소 건수 |
|----|------|----------|
| #580 | `/docs/*` sitemap 기반 301/307 리다이렉트 | ~700건 |
| #581 | `/wiki/*` Confluence 리다이렉트 URL 오류 수정 + 301 전환 | ~171건 |
| **합계** | | **~871건 (www 전체의 34%)** |

## 향후 계획

### P1 — 즉시 실행 가능
1. **robots.txt 정리**: `/wiki/`, `/_next/image`, `/chat/`, `/assets/api-docs.json` Disallow 추가
2. **GSC sitemap 등록 정리**: `/docs/sitemap.xml` (247건), `/wiki/sitemap.xml` (305건) 제거 → ~550건 해소

### P2 — 조사 후 실행
3. **`/resources/` 경로 문제 해소** (778건): 최대 잔여 카테고리, 라우팅 분석 필요
4. **`/sitemap.xml` 오류 조사**: GSC에서 "1 error" 상태
5. **프론트엔드 locale URL 버그 수정**: `/jahttps://...` 패턴 (10건)

### P3 — 중장기
6. docs.querypie.com 미인덱싱 해소 (662건)
7. app.querypie.com 중복 콘텐츠 정리 (169건)
8. 주간 모니터링 체계 운영

## 이 PR에 포함된 파일

- `reports/gsc-indexing-improvement-summary.md` — 종합 진행 요약 문서
- `reports/gsc-index-report-2026-02-06.md` — 주간 인덱싱 상태 리포트
- `reports/data/gsc-index-2026-02-06.json` — 4개 사이트 인덱싱 요약 데이터
- `reports/data/gsc-detail-*.json` — 4개 사이트 상세 URL 데이터 (총 4개 파일)

🤖 Generated with [Claude Code](https://claude.com/claude-code)