### PR TITLE
docs(skill): 코드 변경 전 feature branch 필수 규칙 강화

### DIFF
--- a/skills/ops/branch-workflow.md
+++ b/skills/ops/branch-workflow.md
@@ -12,12 +12,13 @@ Local branch를 최소로 유지하며 항상 최신 main 위에서 작업하는
 
 ## 필수 규칙
 
-> **main 브랜치에 직접 커밋 금지**
+> **코드 변경 전 반드시 feature 브랜치 확인**
 >
-> 커밋 전 반드시 현재 브랜치를 확인하고, feature 브랜치에서 작업할 것.
+> 코드를 수정하기 전에 항상 현재 브랜치를 확인하고, main이면 feature 브랜치를 생성할 것.
+> 이 규칙은 현재 repo뿐 아니라 **외부 repo에서 작업할 때도 동일하게 적용**한다.
 
 ```bash
-# 커밋 전 브랜치 확인 (필수)
+# 코드 변경 전 브랜치 확인 (필수)
 git branch --show-current
 
 # main이면 즉시 feature 브랜치 생성
@@ -98,7 +99,8 @@ git checkout -b <prefix>/<descriptive-name>
 
 | 실수 | 해결 |
 |------|------|
-| **main에 직접 커밋** | 커밋 전 `git branch --show-current` 확인 필수 |
+| **main에서 코드 수정 시작** | 코드 변경 전 `git branch --show-current` 확인 필수 |
+| **외부 repo에서 branch 생성 누락** | 외부 repo도 동일하게 feature branch 생성 후 작업 |
 | main 업데이트 없이 브랜치 생성 | 항상 `git pull` 먼저 |
 | 머지된 브랜치 방치 | PR 상태 확인 후 삭제 |
 | 원격 추적 브랜치 누적 | `git remote prune origin` 실행 |


### PR DESCRIPTION
## Summary
- branch-workflow 필수 규칙의 시점을 "커밋 전"에서 **"코드 변경 전"**으로 앞당김
- **외부 repo에서 작업할 때도** 동일하게 feature branch를 생성해야 함을 명시
- 흔한 실수 테이블에 "외부 repo에서 branch 생성 누락" 항목 추가

## Test plan
- [x] branch-workflow.md 마크다운 렌더링 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)