### PR TITLE
feat: git-cleanup-branches 디렉토리 지정 인자 추가

### DIFF
--- a/bin/git-cleanup-branches
+++ b/bin/git-cleanup-branches
@@ -190,6 +190,11 @@ def main() -> int:
         description="Scan workspace and cleanup stale branches in git repositories",
     )
     parser.add_argument(
+        "dirs",
+        nargs="*",
+        help="Directory names under workspace to scan (default: all repos)",
+    )
+    parser.add_argument(
         "--workspace",
         type=Path,
         default=Path.home() / "workspace",
@@ -219,7 +224,20 @@ def main() -> int:
     print(f"Mode: {'DELETE' if args.delete else 'dry-run'}")
     print()
 
-    repos = find_git_repos(workspace)
+    if args.dirs:
+        repos = []
+        for name in args.dirs:
+            repo_path = workspace / name
+            if not repo_path.is_dir():
+                print(f"Warning: {repo_path} does not exist, skipping")
+            elif not (repo_path / ".git").exists():
+                print(f"Warning: {repo_path} is not a git repository, skipping")
+            else:
+                repos.append(repo_path)
+        repos.sort()
+    else:
+        repos = find_git_repos(workspace)
+
     if not repos:
         print("No git repositories found.")
         return 0


### PR DESCRIPTION
## Summary
- `git-cleanup-branches`에 positional argument로 디렉토리 이름을 지정할 수 있도록 개선
- 지정된 디렉토리만 `~/workspace/` 아래에서 탐색하여 실행 속도 단축
- 인자 없이 실행하면 기존과 동일하게 전체 탐색

## Test plan
- [ ] `git-cleanup-branches repo1 repo2` — 지정 디렉토리만 탐색 확인
- [ ] `git-cleanup-branches` — 기존 전체 탐색 동작 유지 확인
- [ ] 존재하지 않는 디렉토리 지정 시 경고 메시지 출력 확인
- [ ] git repo가 아닌 디렉토리 지정 시 경고 메시지 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)