### PR TITLE
docs(project): bin 리팩토링 프로젝트 문서 최종 업데이트

### DIFF
--- a/projects/active/querypie-docs-bin-refactoring.md
+++ b/projects/active/querypie-docs-bin-refactoring.md
@@ -23,8 +23,8 @@ created: 2026-02-08
 
 | 파일 | 언어 | 줄 수 | 역할 |
 |---|---|---|---|
-| `confluence_xhtml_to_markdown.py` | Python | 2,255 | Confluence XHTML → MDX 변환 (핵심 변환기) |
-| `mdx_to_skeleton.py` | Python | 1,470 | MDX → 스켈레톤 변환 (번역 구조 비교용) |
+| `confluence_xhtml_to_markdown.py` | Python | 2,255 | Confluence XHTML → MDX 변환 (핵심 변환기) → `converter/` 패키지로 분리, 원본 삭제 |
+| `mdx_to_skeleton.py` | Python | 1,470 | MDX → 스켈레톤 변환 (번역 구조 비교용) → `skeleton/cli.py`로 이동, 원본 삭제 |
 | `xhtml2markdown.ko.sh` | Bash | 1,148 | 배치 변환 스크립트 (자동 생성) |
 | `pages_of_confluence.py` | Python | 1,012 | Confluence API 데이터 수집 및 페이지 트리 구성 |
 | `skeleton_diff.py` | Python | 629 | 스켈레톤 파일 diff 엔진 |
@@ -47,8 +47,9 @@ created: 2026-02-08
 | `reverse_sync_cli.py` | 별도 프로젝트로 관리 |
 | `reverse_sync/` (패키지 전체) | 별도 프로젝트로 관리 |
 
-### 현재 모듈 의존 관계
+### 모듈 의존 관계 (리팩토링 전 → 후)
 
+**리팩토링 전:**
 ```
 text_utils.py
   ← confluence_xhtml_to_markdown.py
@@ -59,11 +60,23 @@ skeleton_common.py
   ← mdx_to_skeleton.py
   ← skeleton_diff.py
 
-skeleton_compare.py
-  ← mdx_to_skeleton.py
+skeleton_compare.py ← mdx_to_skeleton.py
+skeleton_diff.py    ← mdx_to_skeleton.py
+```
 
-skeleton_diff.py
-  ← mdx_to_skeleton.py
+**리팩토링 후:**
+```
+text_utils.py
+  ← converter/context.py
+  ← generate_commands_for_xhtml2markdown.py
+  ← pages_of_confluence.py
+
+skeleton/common.py  ← skeleton/cli.py, skeleton/diff.py
+skeleton/compare.py ← skeleton/cli.py
+skeleton/diff.py    ← skeleton/cli.py
+
+converter/context.py ← converter/core.py, converter/cli.py
+converter/core.py    ← converter/cli.py
 ```
 
 ## 식별된 문제점
@@ -116,13 +129,14 @@ skeleton_diff.py
 - [x] `skeleton_compare.py` → `bin/skeleton/compare.py`
 - [x] `skeleton_diff.py` → `bin/skeleton/diff.py`
 - [x] `ignore_skeleton_diff.yaml` → `bin/skeleton/ignore_rules.yaml`
-- [x] `mdx_to_skeleton.py` 로직 → `bin/skeleton/cli.py`, 원본은 backward-compatible shim으로 유지
+- [x] `mdx_to_skeleton.py` → `bin/skeleton/cli.py` (shim 없이 완전 삭제, git rename R099로 인식)
+- [x] `.claude/skills/`, `docs/translation.md` 등 참조 문서 일괄 업데이트
 - [x] 기존 테스트 통과 확인 (pytest 55/55, XHTML 21/21, Skeleton 18/18)
 
 **미적용 항목:**
 - `review-skeleton-diff.sh` 이동: 외부 참조가 있어 하위 디렉토리 이동 시 호환성 위험
 - `DiffProcessor` 클래스 리팩토링: 전역 상태 제거는 기능 변경 위험이 있어 별도 작업으로 분리
-- `ContentProtector`/`TextProcessor` 별도 모듈 분리: 테스트에서 `mdx_to_skeleton` 경유 import 사용 중
+- `ContentProtector`/`TextProcessor` 별도 모듈 분리: 테스트에서 `skeleton.cli` 경유 import 사용 중
 
 ### Phase 3: 변환기 모듈 분리 ✅
 
@@ -131,10 +145,12 @@ skeleton_diff.py
 - [x] `bin/converter/` 패키지 생성 (`__init__.py`)
 - [x] `converter/context.py`: 타입 정의, 전역 상태, 유틸리티 함수 (663줄)
 - [x] `converter/core.py`: 8개 변환 클래스 — Attachment, SingleLineParser, MultiLineParser, TableToNativeMarkdown, TableToHtmlTable, StructuredMacroToCallout, AdfExtensionToCallout, ConfluenceToMarkdown (1445줄)
-- [x] `converter/cli.py`: main() 진입점, generate_meta_from_children (211줄)
+- [x] `converter/cli.py`: main() 진입점, generate_meta_from_children (211줄) + `sys.path` fix for standalone execution
 - [x] 모듈 간 전역 변수 공유: `import converter.context as ctx` + `ctx.VAR = value` 패턴
-- [x] 원본 `confluence_xhtml_to_markdown.py`는 backward-compatible shim으로 유지
-- [x] 기존 테스트 통과 확인 (XHTML 21/21, Skeleton 18/18, pytest 109/109)
+- [x] `confluence_xhtml_to_markdown.py` 완전 삭제 (shim 없이), 모든 호출자를 `converter/cli.py`로 업데이트
+- [x] 참조 업데이트: `entrypoint.sh`, `run-tests.sh`, `reverse_sync_cli.py`, `generate_commands_for_xhtml2markdown.py`, `generated/xhtml2markdown.ko.sh`, `.claude/skills/`, `docs/`, `README.md` 등 13개 파일
+- [x] `.gitignore`에 `converter/__pycache__/`, `skeleton/__pycache__/` 추가
+- [x] 기존 테스트 통과 확인 (XHTML 21/21, Skeleton 18/18, pytest 147/147)
 
 ### Phase 4: 유틸리티 및 동기화 도구 정리 ✅
 
@@ -143,7 +159,7 @@ skeleton_diff.py
 - [x] `translate_titles.py`에 argparse 추가, 하드코딩된 파일 경로를 CLI 인자로 변경
 - [x] `pages_of_confluence.py` 타입 힌트: `Config.email/api_token` 및 `Page` dataclass 필드에 `Optional` 적용
 - [x] `converter/core.py` 타입 힌트: `Attachment.as_markdown(align)` 파라미터 `Optional` 적용
-- [x] 기존 테스트 통과 확인 (XHTML 21/21, pytest 109/109)
+- [x] 기존 테스트 통과 확인 (XHTML 21/21, pytest 149/149)
 
 **미적용 항목:**
 - 번역 로직 통합: `translate_titles.py`와 `pages_of_confluence.py`의 중복은 약 15줄로, 통합 시 불필요한 의존성(requests 등) 발생. 비용 대비 효과 부족
@@ -167,14 +183,16 @@ skeleton_diff.py
 
 ## 실행 결과
 
-**querypie-docs 브랜치:** `refactor/confluence-mdx-bin` (4 commits)
+**PR 전략:** Phase별 독립 브랜치 → 각각 main에 rebase 후 merge (stacked PR 아닌 독립 PR)
 
-| Phase | Commit | 테스트 결과 |
-|---|---|---|
-| Phase 1 | `refactor(bin): Phase 1 - 파일명 정규화 및 디렉토리 구조 개선` | XHTML 21/21, Skeleton 18/18 |
-| Phase 2 | `refactor(bin): Phase 2 - 스켈레톤 모듈 bin/skeleton/ 패키지화` | pytest 55/55, XHTML 21/21, Skeleton 18/18 |
-| Phase 3 | `refactor(bin): Phase 3 - 변환기 모듈 bin/converter/ 패키지 분리` | XHTML 21/21, Skeleton 18/18, pytest 109/109 |
-| Phase 4 | `refactor(bin): Phase 4 - 유틸리티 정리 및 타입 힌트 개선` | XHTML 21/21, pytest 109/109 |
+| Phase | 브랜치 | PR | 상태 |
+|---|---|---|---|
+| Phase 1 | `refactor/bin-phase-1` | #628 | ✅ Merged |
+| Phase 2 | `refactor/bin-phase-2` | #629 | ✅ Merged |
+| Phase 3 | `refactor/bin-phase-3` | #630 | ✅ Merged |
+| Phase 4 | `refactor/bin-phase-4` | #631 | ✅ Merged |
+
+**최종 테스트 결과:** pytest 149/149, XHTML 21/21, Skeleton 18/18
 
 ### 최종 디렉토리 구조
 
@@ -184,28 +202,50 @@ bin/
 │   ├── __init__.py
 │   ├── context.py             # 타입, 전역 상태, 유틸리티 (663줄)
 │   ├── core.py                # 8개 변환 클래스 (1445줄)
-│   └── cli.py                 # main() 진입점 (211줄)
+│   └── cli.py                 # main() 진입점 (211줄, sys.path fix 포함)
 ├── skeleton/                   # Phase 2: 스켈레톤 처리 패키지
 │   ├── __init__.py
-│   ├── cli.py                 # mdx_to_skeleton 핵심 로직
+│   ├── cli.py                 # mdx_to_skeleton 핵심 로직 (mdx_to_skeleton.py에서 이동)
 │   ├── common.py              # 공유 유틸리티
 │   ├── compare.py             # ko/en/ja 비교
 │   ├── diff.py                # diff 엔진
 │   └── ignore_rules.yaml      # diff 예외 규칙
 ├── generated/                  # Phase 1: 자동 생성 파일 격리
 │   └── xhtml2markdown.ko.sh
-├── confluence_xhtml_to_markdown.py  # Shim → converter.cli
-├── mdx_to_skeleton.py              # Shim → skeleton.cli
-├── setup-cache.sh                   # Phase 1: 숫자 접두사 제거
+├── setup-cache.sh             # Phase 1: 숫자 접두사 제거
 ├── text_utils.py
 ├── pages_of_confluence.py
-├── translate_titles.py              # Phase 4: argparse 추가
+├── translate_titles.py        # Phase 4: argparse 추가
 ├── ... (기타 유틸리티)
-└── reverse_sync/                    # 별도 관리 (이번 범위 제외)
+└── reverse_sync/              # 별도 관리 (이번 범위 제외)
 ```
+
+**삭제된 파일:**
+- `confluence_xhtml_to_markdown.py` — `converter/cli.py`로 완전 대체, shim 미유지
+- `mdx_to_skeleton.py` — `skeleton/cli.py`로 완전 이동 (git rename R099), shim 미유지
 
 ## 메모
 
-- 모든 Phase를 단일 브랜치 `refactor/confluence-mdx-bin`에서 순차 실행
-- backward-compatible shim 패턴으로 기존 호출 경로(entrypoint.sh, run-tests.sh, GHA workflow) 유지
+### Shim 전략 변경
+
+초기 계획은 backward-compatible shim을 유지하는 것이었으나, 최종적으로 shim 없이 원본 파일을 완전 삭제하고 모든 호출자를 직접 업데이트하는 방식으로 변경하였다. 이유:
+- Shim 유지 시 git이 파일 이동을 rename으로 인식하지 못함 (M+A로 표시)
+- 호출자가 명확히 파악 가능하여, 직접 업데이트가 더 깔끔함
+- `converter/cli.py`에 `sys.path` fix를 추가하여 standalone 실행 지원 (`python bin/converter/cli.py` 직접 호출 가능)
+
+### PR 운영
+
+- 초기에는 단일 브랜치 `refactor/confluence-mdx-bin`에서 4개 커밋으로 진행하였으나, 리뷰 편의를 위해 Phase별 독립 브랜치로 분리
+- Phase 1 merge 후 Phase 2를 main에 rebase (cherry-pick), Phase 2 merge 후 Phase 3를 main에 rebase, ... 순차 진행
+- `--force-with-lease`로 안전한 force push 사용
+
+### 기술 참고
+
 - 모듈 간 전역 변수 공유 시 Python gotcha 주의: `from module import VAR`로 import 후 `global VAR; VAR = x`는 원본 모듈에 반영되지 않음. `import module as m; m.VAR = x` 패턴 사용 필요
+- `PYTHONPATH=bin` prefix 또는 `export PYTHONPATH="${BIN_DIR}:${PYTHONPATH:-}"`가 shell-based test runner에서 필요
+- 테스트 실행 전 `make clean`으로 stale output 파일 정리 권장 (이전 변환기 버전의 출력물이 잔존할 수 있음)
+
+### 향후 검토 사항
+
+- `converter/core.py` (1445줄) 클래스 수준 분리: `TableToNativeMarkdown`/`TableToHtmlTable` → `tables.py`, `StructuredMacroToCallout`/`AdfExtensionToCallout` → `callouts.py`, `Attachment` → `attachment.py` 등 가능. 단, `SingleLineParser` ↔ `MultiLineParser`는 양방향 재귀 호출로 분리 곤란
+- `DiffProcessor` 전역 상태 제거 (skeleton/diff.py)


### PR DESCRIPTION
## Summary
- querypie-docs bin 리팩토링 4-Phase 완료에 따른 프로젝트 문서 최종 반영
- Shim 전략 변경 (유지 → 완전 삭제), PR 전략 변경 (단일 브랜치 → Phase별 독립 PR #628~#631)
- 모듈 의존 관계 다이어그램, 최종 디렉토리 구조, 테스트 결과, 향후 검토 사항 업데이트

## Test plan
- [x] 문서 변경만 포함, 코드 변경 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)