### PR TITLE
docs(project): reverse-sync 프로젝트 현황 업데이트 (Sidecar 전환 완료)

### DIFF
--- a/projects/active/querypie-docs-reverse-sync-phase1-retrospective.md
+++ b/projects/active/querypie-docs-reverse-sync-phase1-retrospective.md
@@ -1,7 +1,7 @@
 # QueryPie Docs Reverse Sync — Phase 1 회고 및 개선 방안
 
-> **Status:** 검토 중
-> **관련 프로젝트:** [Phase 1 (완료)](../done/querypie-docs-reverse-sync.md) · [Phase 2/3 (미착수)](querypie-docs-reverse-sync-phase2.md)
+> **Status:** 조치 완료 — 즉시 조치 3건 중 2건 완료, 매핑 재설계(Sidecar) 완료
+> **관련 프로젝트:** [Phase 1 (완료)](../done/querypie-docs-reverse-sync.md) · [Phase 2/3 (미착수)](querypie-docs-reverse-sync-phase2.md) · [매핑 재설계 (완료)](querypie-docs-reverse-sync-mapping-redesign.md)
 > **분석 대상 기간:** 2026-02-08 ~ 2026-02-11 (PR #609 ~ #677)
 > **분석 목적:** Phase 1 "완료" 이후 지속되는 bug fix PR의 근본 원인을 파악하고, Phase 2 착수 전 설계 개선 방안을 도출한다.
 
@@ -259,21 +259,22 @@ XHTML 요소 → (forward converter 로직) → MDX 텍스트 → strip markers 
 
 ### 5.1 즉시 조치 (Phase 1 안정화)
 
-1. ~~Open PR 5건 (#673~#677) 리뷰 및 머지~~ 상태 확인 후 진행
-2. `reverse_sync_cli.py` 리팩토링 (Section 4.1-A) — 모듈 분리
-3. 정규화 테스트 매트릭스 구축 (Section 4.1-B)
-4. 매칭 실패 로깅 강화 (Section 4.1-C)
+1. ~~Open PR 5건 (#673~#677) 리뷰 및 머지~~ → **완료** (2026-02-11, 전부 머지)
+2. ~~`reverse_sync_cli.py` 리팩토링 (Section 4.1-A) — 모듈 분리~~ → **완료** (querypie-docs#679: `text_normalizer.py`, `block_matcher.py`, `text_transfer.py`, `patch_builder.py` 4개 모듈 분리)
+3. 정규화 테스트 매트릭스 구축 (Section 4.1-B) — 미착수 (Sidecar 전환으로 정규화 의존도 대폭 감소)
+4. 매칭 실패 로깅 강화 (Section 4.1-C) — 미착수 (Sidecar 전환으로 fuzzy matching 제거됨)
 
 ### 5.2 Phase 2 착수 전 필수 검토
 
-1. **Block ID Embedding 방안 결정** (Section 4.2-D)
-   - forward converter 수정 비용 vs 현재 fuzzy matching 유지 비용 비교
-   - Phase 2의 구조적 변경 매핑에 필수적
-2. **공통 Plain Text 추출기 설계** (Section 4.2-E)
-   - 정규화 whack-a-mole 패턴의 근본 해결
+1. ~~**Block ID Embedding 방안 결정** (Section 4.2-D)~~ → **완료** — Sidecar Mapping File 방식으로 결정 및 구현 완료 ([매핑 재설계 문서](querypie-docs-reverse-sync-mapping-redesign.md) 참조)
+   - Forward converter가 `var/<page_id>/mapping.yaml` 생성 (querypie-docs#682)
+   - Reverse-sync pipeline이 sidecar O(1) 직접 조회로 전환 (querypie-docs#688, #694)
+   - Fuzzy matching 완전 제거, `block_matcher.py` 삭제
+2. **공통 Plain Text 추출기 설계** (Section 4.2-E) — 미착수 (Sidecar 전환으로 정규화 의존도 대폭 감소하여 우선순위 하락)
 3. 현재 테스트 커버리지 검토
-   - 19개 testcase가 전체 문서 유형을 충분히 커버하는지 확인
-   - 특히 table, ADF panel, nested list, multi-language 문서에 대한 커버리지
+   - pytest 251개로 확대 (Phase 1 초기 대비 +49)
+   - 148개 페이지 배치 verify 100% 통과
+   - 특히 table, ADF panel, nested list, multi-language 문서에 대한 커버리지 추가 필요
 
 ### 5.3 결론
 
@@ -332,9 +333,9 @@ Phase 1의 reverse-sync는 **빠른 프로토타이핑**에 성공했다. 3일�
 | #633 | fix(reverse_sync): innerHTML 교체 시 old_plain_text 검증 가드 추가 | 02-09 |
 | #632 | feat(reverse_sync): MDX→XHTML inner HTML 변환 모듈 추가 | 02-09 |
 
-### Open (5건)
+### ~~Open (5건)~~ → 전부 Merged (2026-02-11)
 
-| PR | 제목 | 생성일 |
+| PR | 제목 | 머지일 |
 |----|------|--------|
 | #677 | feat(pages_of_confluence): --recent 모드에서 변경 범위 자동 판별 기능 추가 | 02-11 |
 | #676 | fix(reverse-sync): Markdown table 행별 분리 매칭 및 패딩 정규화 | 02-11 |

--- a/projects/active/querypie-docs-reverse-sync-phase2.md
+++ b/projects/active/querypie-docs-reverse-sync-phase2.md
@@ -1,8 +1,10 @@
 # QueryPie Docs Reverse Sync — Phase 2/3
 
-> **Status:** Not Started
+> **Status:** Not Started — 전제조건(Sidecar 매핑, 오케스트레이터 분리) 완료
 > **Target Repo:** [querypie/querypie-docs/confluence-mdx][repo]
 > **Phase 1:** [완료](../done/querypie-docs-reverse-sync.md)
+> **매핑 재설계:** [완료](querypie-docs-reverse-sync-mapping-redesign.md)
+> **Phase 1 회고:** [조치 완료](querypie-docs-reverse-sync-phase1-retrospective.md)
 
 [repo]: https://github.com/querypie/querypie-docs/tree/main/confluence-mdx
 
@@ -13,6 +15,19 @@ Phase 1(텍스트 수준 변경)에서 구축한 reverse-sync 파이프라인을
 ### 배경
 
 Phase 1은 블록 수가 동일한 텍스트 변경만 처리한다. AI Agent가 헤딩을 재구성하거나 섹션을 분리/통합하는 등 구조적 편집을 수행하면, 현재 파이프라인에서는 블록 수 불일치 에러가 발생한다.
+
+### 완료된 전제조건
+
+Phase 1 회고에서 도출된 설계 개선 작업이 완료되어 Phase 2 착수 기반이 마련되었다:
+
+| 항목 | PR | 상태 |
+|------|-----|------|
+| Sidecar mapping 파일 생성 (Forward converter) | querypie-docs#682 | 완료 |
+| Sidecar lookup 모듈 + 유닛 테스트 | querypie-docs#685, #687 | 완료 |
+| Fuzzy matching 제거, sidecar 전용 매칭 전환 | querypie-docs#688, #694 | 완료 |
+| `reverse_sync_cli.py` 4개 모듈 분리 리팩토링 | querypie-docs#679 | 완료 |
+| `pages_of_confluence.py` 모듈 분리 | querypie-docs#678 | 완료 |
+| `pages.yaml` 기반 일괄 변환 파이프라인 | querypie-docs#681 | 완료 |
 
 ### 변경 범위
 
@@ -38,6 +53,7 @@ Phase 1은 블록 수가 동일한 텍스트 변경만 처리한다. AI Agent가
 - 시퀀스 정렬: difflib `SequenceMatcher` 또는 LCS 기반 알고리즘 검토
 - 추가된 블록의 XHTML 변환: Confluence 매크로(`ac:structured-macro` 등)를 생성해야 하므로 forward converter의 역변환 로직이 필요
 - 검증: Phase 1의 round-trip 검증 프레임워크 재활용 가능
+- **Sidecar 매핑 활용**: 블록 추가/삭제 시 매핑 인덱스 변동 처리 전략 필요 (매핑 재설계 문서 "추후 별도 검토" 참조)
 
 ---
 
@@ -59,7 +75,11 @@ Phase 1은 블록 수가 동일한 텍스트 변경만 처리한다. AI Agent가
 
 ## 진행 로그
 
-(아직 시작 전)
+| 날짜 | PR | 내용 |
+|------|-----|------|
+| 2026-02-13 | querypie-docs#694 | Sidecar 전용 매칭 전환 완료 — Phase 2 전제조건 충족 |
+| 2026-02-12 | querypie-docs#688 | Fuzzy matching 제거, sidecar pipeline 전환 |
+| 2026-02-11 | querypie-docs#679 | 오케스트레이터 4개 모듈 분리 리팩토링 |
 
 ## 진행 상태
 


### PR DESCRIPTION
## Summary
- **mapping-redesign.md**: Status → Completed, sidecar pipeline 전환 PR(#685~#694) 반영, 검증 결과 갱신 (251 pytest, 148페이지 배치 verify 100%)
- **phase1-retrospective.md**: Open PR 5건 전부 머지 반영, 즉시 조치 2건 완료 (오케스트레이터 분리 #679), Sidecar 전환으로 나머지 조치 불필요 처리
- **phase2.md**: 전제조건(Sidecar 매핑, 모듈 분리) 완료 테이블 추가, 진행 로그 갱신

## Test plan
- [x] 문서 내 PR 번호/날짜가 querypie-docs 실제 PR과 일치하는지 확인
- [x] 체크박스 상태가 실제 구현 상태를 정확히 반영하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)