### PR TITLE
fix: prevent applied issue reopen cycle in debate-review

### DIFF
--- a/skills/cc-codex-debate-review/SKILL.md
+++ b/skills/cc-codex-debate-review/SKILL.md
@@ -210,6 +210,31 @@ Call `upsert-issue` for each finding from the lead agent:
 
 `anchor` should prefer symbol names, function names, or other identifiers less sensitive to line shifts. Use `line<N>` if none exists.
 
+#### Reopen Review for Applied Issues
+
+If `upsert-issue` returns `action: "reopen_requires_review"`, the issue was previously fixed and applied. The response includes:
+- `new_message`: the agent's new finding
+- `existing_reports`: array of previous reports (`agent`, `round`, `message`)
+
+The orchestrator **must** compare the new message against the existing reports and decide:
+
+- **Same concern re-reported** (describing the fix itself, or repeating the original problem) → **skip** the reopen. Do not call `upsert-issue` again.
+- **Genuinely new concern** about the same location (e.g., the fix introduced a new bug, or a different aspect was missed) → call `upsert-issue` again with `--confirm-reopen`:
+
+```bash
+"$DEBATE_REVIEW_BIN" upsert-issue \
+  --state-file "$STATE_FILE" \
+  --agent "$LEAD_AGENT" \
+  --round "$CURRENT_ROUND" \
+  --confirm-reopen \
+  --severity "warning" \
+  --criterion 2 \
+  --file "src/foo.ts" \
+  --line 42 \
+  --anchor "validate_input" \
+  --message "New concern about this location"
+```
+
 #### Record Verdict
 
 ```bash

--- a/skills/cc-codex-debate-review/codex-cross-verify-prompt.md
+++ b/skills/cc-codex-debate-review/codex-cross-verify-prompt.md
@@ -29,6 +29,11 @@ Review the diff independently according to the criteria below. Report any additi
 
 **Re-raise rule:** To re-raise an issue recorded as `withdrawn` in the Debate Ledger, you must provide **new evidence different from** the original withdrawal reason in your `message`. Repeating the same rationale is not allowed.
 
+**Before reporting a finding, check the Debate Ledger above:**
+- Do NOT report code that was added as a fix for a previously accepted issue. Describing a fix is not a finding.
+- Do NOT report something that is working correctly. "X uses correct flag" or "X matches the spec" is not an issue.
+- If unsure whether something is a real issue, err on the side of **not reporting** it. Unnecessary findings waste rounds and block consensus.
+
 ## Output Language
 
 Use `{OUTPUT_LANGUAGE}` for all user-facing JSON string values you generate, including `message`, `reason`, and `description`. Keep JSON keys, enum values, file paths, anchors, and diff syntax unchanged.

--- a/skills/cc-codex-debate-review/codex-lead-review-prompt.md
+++ b/skills/cc-codex-debate-review/codex-lead-review-prompt.md
@@ -40,6 +40,12 @@ Review the diff according to the criteria below. Identify all issues by severity
 
 If you decided `maintain` on any rebuttal in Step 1a, include that issue in your findings here.
 
+**Before reporting a finding, check the Debate Ledger and Open Issues above:**
+- Do NOT re-report an issue that was already withdrawn — unless you have **new evidence** not covered by the withdrawal reason.
+- Do NOT report code that was added as a fix for a previously accepted issue. Describing a fix is not a finding.
+- Do NOT report something that is working correctly. "X uses correct flag" or "X matches the spec" is not an issue.
+- If unsure whether something is a real issue, err on the side of **not reporting** it. Unnecessary findings waste rounds and block consensus.
+
 ## Verdict
 
 - If findings are **0** and `{OPEN_ISSUES}` is an empty array → set verdict to `no_findings_mergeable`

--- a/skills/cc-codex-debate-review/lib/debate_review/cli.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/cli.py
@@ -57,6 +57,8 @@ def build_parser() -> argparse.ArgumentParser:
     p_upsert.add_argument("--line", type=int, required=True)
     p_upsert.add_argument("--anchor", required=True)
     p_upsert.add_argument("--message", required=True)
+    p_upsert.add_argument("--confirm-reopen", action="store_true",
+                          help="Confirm reopening an already-applied issue")
 
     # init-round subcommand
     p_initr = subparsers.add_parser("init-round", help="Initialize a new round")
@@ -317,6 +319,7 @@ def cmd_upsert_issue(args):
         line=args.line,
         anchor=args.anchor,
         message=args.message,
+        confirm_reopen=args.confirm_reopen,
     )
     save_state(state, args.state_file)
     print(json.dumps(result))

--- a/skills/cc-codex-debate-review/lib/debate_review/issue_ops.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/issue_ops.py
@@ -93,6 +93,7 @@ def upsert_issue(
     line: int,
     anchor: str,
     message: str,
+    confirm_reopen: bool = False,
 ) -> dict:
     issues = state["issues"]
     issue_key = generate_issue_key(criterion=criterion, file=file, anchor=anchor, message=message)
@@ -158,6 +159,18 @@ def upsert_issue(
         issue["accepted_by"] = [agent]
         issue["reopened_in_round"] = round_num
     elif application_status == "applied":
+        if not confirm_reopen:
+            # Return existing reports for the orchestrator to review before reopening
+            existing_messages = [
+                {"agent": r["agent"], "round": r["round"], "message": r["message"]}
+                for r in issue.get("reports", [])
+            ]
+            return {
+                "issue_id": existing_id, "report_id": None,
+                "action": "reopen_requires_review", "issue_key": issue_key,
+                "new_message": message,
+                "existing_reports": existing_messages,
+            }
         issue["consensus_status"] = "open"
         issue["consensus_reason"] = None
         issue["application_status"] = "pending"

--- a/skills/cc-codex-debate-review/tests/test_issue_ops.py
+++ b/skills/cc-codex-debate-review/tests/test_issue_ops.py
@@ -154,6 +154,7 @@ def test_upsert_resets_applied_issue(sample_state):
     sample_state["issues"][issue_id]["applied_by"] = "codex"
     sample_state["issues"][issue_id]["application_commit_sha"] = "deadbeef"
 
+    # Without confirm_reopen → returns reopen_requires_review with existing reports
     result = upsert_issue(
         sample_state,
         agent="codex",
@@ -165,13 +166,53 @@ def test_upsert_resets_applied_issue(sample_state):
         anchor="L99",
         message="unused variable x",
     )
+    assert result["action"] == "reopen_requires_review"
+    assert result["report_id"] is None
+    assert result["existing_reports"][0]["message"] == "unused variable x"
+    assert result["new_message"] == "unused variable x"
+    # Issue stays applied — not modified
+    issue = sample_state["issues"][issue_id]
+    assert issue["consensus_status"] == "accepted"
+    assert issue["application_status"] == "applied"
+
+
+def test_upsert_reopens_applied_issue_with_confirm(sample_state):
+    upsert_issue(
+        sample_state,
+        agent="cc",
+        round_num=1,
+        severity="suggestion",
+        criterion=6,
+        file="src/baz.py",
+        line=99,
+        anchor="L99",
+        message="unused variable x",
+    )
+    issue_id = list(sample_state["issues"].keys())[0]
+    sample_state["issues"][issue_id]["consensus_status"] = "accepted"
+    sample_state["issues"][issue_id]["application_status"] = "applied"
+    sample_state["issues"][issue_id]["applied_by"] = "codex"
+    sample_state["issues"][issue_id]["application_commit_sha"] = "deadbeef"
+
+    # With confirm_reopen=True → reopen proceeds
+    result = upsert_issue(
+        sample_state,
+        agent="codex",
+        round_num=2,
+        severity="suggestion",
+        criterion=6,
+        file="src/baz.py",
+        line=99,
+        anchor="L99",
+        message="variable x is assigned but the new assignment shadows the outer scope",
+        confirm_reopen=True,
+    )
     assert result["action"] == "appended"
     issue = sample_state["issues"][issue_id]
     assert issue["consensus_status"] == "open"
     assert issue["application_status"] == "pending"
     assert issue["applied_by"] is None
-    assert issue["application_commit_sha"] is None
-    assert issue["accepted_by"] == ["codex"]  # reset to reporting agent only
+    assert issue["accepted_by"] == ["codex"]
 
 
 def test_upsert_tracks_cross_verifier_reports_in_step2():


### PR DESCRIPTION
## Summary

- debate-review에서 applied 이슈가 동일 key로 재보고될 때 무조건 reopen되어 합의에 도달하지 못하는 무한 루프 수정
- `upsert-issue`가 applied 이슈를 만나면 `reopen_requires_review`를 반환하여 오케스트레이터(CC)가 기존 보고와 비교 후 AI 판단으로 reopen 여부 결정
- Codex 프롬프트에 불필요한 finding 방지 지침 추가 (수정 코드를 이슈로 보고 금지, 정상 작동 코드 보고 금지)

## Test plan

- [x] `test_upsert_resets_applied_issue` — applied 이슈 재보고 시 `reopen_requires_review` 반환 확인
- [x] `test_upsert_reopens_applied_issue_with_confirm` — `confirm_reopen=True` 시 정상 reopen 확인
- [x] 전체 142개 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)