### PR TITLE
feat: add test-error subcommand for error reporting pipeline verification

### DIFF
--- a/skills/cc-codex-debate-review/SKILL.md
+++ b/skills/cc-codex-debate-review/SKILL.md
@@ -720,6 +720,18 @@ When `DRY_RUN=false`, the `error_log` field in the `mark-failed` response contai
 
 **Do not silently retry or ignore errors.** Every failure must go through `mark-failed`. When `DRY_RUN=false`, also file the bug report before session termination.
 
+### Testing the Error Reporting Pipeline
+
+Use the `test-error` subcommand to verify the error reporting pipeline works end-to-end. This command intentionally raises a RuntimeError, simulating a real CLI failure.
+
+To test, replace any CLI call in the orchestration flow with `test-error`:
+
+```bash
+RESULT=$("$DEBATE_REVIEW_BIN" test-error --message "simulated sync-head failure") || true
+```
+
+The orchestrator must handle this failure exactly like a real error — capture the error, call `mark-failed`, save the error log, and create a GitHub Issue. No special handling for `test-error`; it goes through the standard failure path.
+
 ## Common Mistakes
 
 - **Manipulating state without CLI**: Always use `$DEBATE_REVIEW_BIN` subcommands for state changes

--- a/skills/cc-codex-debate-review/lib/debate_review/cli.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/cli.py
@@ -112,6 +112,10 @@ def build_parser() -> argparse.ArgumentParser:
     p_ledger.add_argument("--state-file", required=True)
     p_ledger.add_argument("--entries", required=True, help="JSON array of ledger entries")
 
+    # test-error subcommand
+    p_test = subparsers.add_parser("test-error", help="Trigger an intentional error for pipeline verification")
+    p_test.add_argument("--message", default="Intentional test error for pipeline verification")
+
     # build-context subcommand
     p_ctx = subparsers.add_parser("build-context", help="Build review context from state")
     p_ctx.add_argument("--state-file", required=True)
@@ -469,6 +473,10 @@ def cmd_mark_failed(args):
     print(json.dumps(result))
 
 
+def cmd_test_error(args):
+    raise RuntimeError(args.message)
+
+
 def cmd_append_ledger(args):
     state = load_state(args.state_file)
     if state is None:
@@ -505,6 +513,7 @@ def main():
         "resolve-rebuttals": cmd_resolve_rebuttals,
         "record-application": cmd_record_application,
         "build-context": cmd_build_context,
+        "test-error": cmd_test_error,
         "mark-failed": cmd_mark_failed,
         "append-ledger": cmd_append_ledger,
         "sync-head": cmd_sync_head,

--- a/skills/cc-codex-debate-review/tests/test_cli.py
+++ b/skills/cc-codex-debate-review/tests/test_cli.py
@@ -549,3 +549,28 @@ def test_cli_record_application_warns_all_failed(monkeypatch, capsys, state_path
     assert result["failed"] == 1
     assert "WARNING" in captured.err
     assert "applied=0" in captured.err
+
+
+def test_cli_test_error_exits_with_json_error(monkeypatch, capsys):
+    """test-error should raise RuntimeError → _error_exit → JSON error + exit 1."""
+    monkeypatch.setattr(sys, "argv", ["debate-review", "test-error"])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert "error" in result
+    assert "Intentional test error" in result["error"]
+
+
+def test_cli_test_error_custom_message(monkeypatch, capsys):
+    """test-error --message should use the custom message."""
+    monkeypatch.setattr(sys, "argv", [
+        "debate-review", "test-error", "--message", "custom failure"
+    ])
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+    assert exc_info.value.code == 1
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert result["error"] == "custom failure"


### PR DESCRIPTION
## Summary

debate-review CLI에 `test-error` subcommand를 추가하여 에러 리포팅 파이프라인을 E2E 검증할 수 있도록 함.

- `debate-review test-error [--message MSG]` — 의도적으로 RuntimeError를 발생시켜 실제 CLI 실패와 동일한 에러 경로를 통과
- SKILL.md에 에러 파이프라인 테스트 절차 문서화
- 단위 테스트 2개 추가 (기본 메시지, 커스텀 메시지)

## E2E 검증 결과

PR #145 대상으로 실제 debate-review 세션을 실행하여 파이프라인을 검증함:

| 단계 | 결과 |
|------|------|
| `test-error` 호출 | JSON 에러 출력 + exit 1 ✅ |
| `mark-failed` 호출 | 상태 → `failed`, 에러 로그 저장 ✅ |
| 에러 로그 파일 생성 | `~/.claude/debate-state/error-logs/` 에 정상 저장 ✅ |
| GitHub Issue 생성 | #146 ✅ |

## Test plan

- [x] `pytest` 22개 테스트 통과
- [x] `debate-review test-error` 실행 시 JSON 에러 출력 + exit code 1 확인
- [x] 실제 debate-review 세션에서 `test-error` → `mark-failed` → error log → GitHub Issue (#146) 생성 E2E 검증 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)