### PR TITLE
feat: support user-level config override for debate-review

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/config.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/config.py
@@ -24,8 +24,22 @@ def load_config(path=None) -> dict:
     try:
         with open(_USER_OVERRIDE_PATH) as f:
             overrides = yaml.safe_load(f) or {}
-        config.update(overrides)
+        if not isinstance(overrides, dict):
+            import sys
+            print(
+                f"WARNING: {_USER_OVERRIDE_PATH} does not contain a YAML mapping; ignoring overrides",
+                file=sys.stderr,
+            )
+        else:
+            config.update(overrides)
     except FileNotFoundError:
         pass
+    except yaml.YAMLError:
+        import sys
+        print(
+            f"WARNING: {_USER_OVERRIDE_PATH} contains invalid YAML; ignoring overrides",
+            file=sys.stderr,
+        )
+
 
     return config

--- a/skills/cc-codex-debate-review/tests/test_state.py
+++ b/skills/cc-codex-debate-review/tests/test_state.py
@@ -170,6 +170,28 @@ def test_load_config_missing_explicit_raises():
         load_config("/nonexistent/path/config.yml")
 
 
+def test_load_config_malformed_yaml_override(monkeypatch, tmp_path):
+    """Malformed YAML in override file should fall back to defaults."""
+    from debate_review import config as config_module
+    override_file = tmp_path / "bad.yml"
+    override_file.write_text(": :\n  - :\n bad: [")
+    monkeypatch.setattr(config_module, "_USER_OVERRIDE_PATH", str(override_file))
+    result = config_module.load_config()
+    assert result["max_rounds"] == 10
+    assert result["language"] == "en"
+
+
+def test_load_config_non_dict_yaml_override(monkeypatch, tmp_path):
+    """Non-dict YAML in override file should fall back to defaults."""
+    from debate_review import config as config_module
+    override_file = tmp_path / "list.yml"
+    override_file.write_text("- ko\n- en\n")
+    monkeypatch.setattr(config_module, "_USER_OVERRIDE_PATH", str(override_file))
+    result = config_module.load_config()
+    assert result["max_rounds"] == 10
+    assert result["language"] == "en"
+
+
 # determine_next_step tests
 
 def test_next_step_from_init(sample_state):


### PR DESCRIPTION
## Summary

- `~/.claude/debate-review-config.yml` 파일로 기본 `config.yml` 값을 override할 수 있도록 지원
- repo의 `config.yml`에는 기본값(`language: en`) 유지, 개인 설정은 `~/.claude/` 아래에서 관리
- YAML 파싱 에러 및 비-dict 형식에 대한 방어 처리 추가 (경고 출력 후 기본값 유지)

## Changes from debate review

- `yaml.YAMLError` catch 추가 — override 파일 문법 오류 시 경고 출력 후 기본 config 사용
- `isinstance(overrides, dict)` 검증 — YAML은 유효하지만 mapping이 아닌 경우(예: `- ko`) 방어

## Test plan

- [x] override 파일 없을 때 기본값만 사용
- [x] override 파일 있을 때 해당 값으로 덮어쓰기
- [x] 잘못된 YAML override 파일 → 경고 출력 + 기본값 유지
- [x] 비-dict YAML override 파일 → 경고 출력 + 기본값 유지
- [x] 전체 테스트 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)