### PR TITLE
fix(debate-review): populate debate_ledger in settle_round

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/round_ops.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/round_ops.py
@@ -1,5 +1,8 @@
 from datetime import datetime, timezone
 
+from debate_review.issue_ops import latest_report_message
+from debate_review.state import append_ledger
+
 
 def init_round(state, *, round_num, lead_agent=None, synced_head_sha):
     if lead_agent is None:
@@ -163,6 +166,20 @@ def settle_round(state, *, round_num) -> dict:
             })
 
     round_["step4"]["settled_issues"] = settled_issues
+
+    # Populate debate_ledger with settled issues
+    if settled_issues:
+        ledger_entries = [
+            {
+                "issue_id": si["issue_id"],
+                "status": si["consensus_status"],
+                "round": round_num,
+                "summary": latest_report_message(issues[si["issue_id"]]),
+                "reason": si.get("consensus_reason"),
+            }
+            for si in settled_issues
+        ]
+        append_ledger(state, entries=ledger_entries)
 
     # Check consensus: last 2 completed rounds both have clean_pass==True
     # AND different lead agents (spec requirement)

--- a/skills/cc-codex-debate-review/tests/test_round_ops.py
+++ b/skills/cc-codex-debate-review/tests/test_round_ops.py
@@ -441,3 +441,30 @@ def test_settle_stall_resets_after_progress(sample_state):
     assert r3_result["result"] == "continue"
     # stall_count is 1, NOT 2 — the progress in round 2 reset the streak
     assert r3_result.get("stall_count") == 1
+
+
+def test_settle_populates_debate_ledger(sample_state):
+    """settle_round should populate state['debate_ledger'] with settled issues."""
+    from debate_review.issue_ops import upsert_issue
+    from debate_review.cross_verification import record_cross_verification, resolve_rebuttals
+
+    init_round(sample_state, round_num=1, lead_agent="codex", synced_head_sha="abc")
+    r1 = upsert_issue(sample_state, agent="codex", round_num=1, severity="warning",
+                       criterion=3, file="src/foo.ts", line=42, anchor="retry",
+                       message="unbounded loop")
+    report_id = r1["report_id"]
+    issue_id = r1["issue_id"]
+    # cc rebuts, codex withdraws
+    record_cross_verification(sample_state, round_num=1,
+                              verifications=[{"report_id": report_id, "decision": "rebut", "reason": "scope"}])
+    resolve_rebuttals(sample_state, round_num=1, step="3",
+                      decisions=[{"report_id": report_id, "decision": "withdraw", "reason": "rebuttal accepted"}])
+    record_verdict(sample_state, round_num=1, verdict="has_findings")
+    settle_round(sample_state, round_num=1)
+
+    ledger = sample_state["debate_ledger"]
+    assert len(ledger) == 1
+    entry = ledger[0]
+    assert entry["issue_id"] == issue_id
+    assert entry["status"] == "withdrawn"
+    assert entry["round"] == 1


### PR DESCRIPTION
## Summary
- settle_round now calls append_ledger to populate state["debate_ledger"] with settled issues
- Previously, debate_ledger was never written, causing build_debate_ledger_text to always return "(First round)"

## Test plan
- [ ] New test: settle_round populates debate_ledger with settled issues
- [ ] Existing tests pass (197 passed)

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)