### PR TITLE
fix(debate-review): execute phases sequentially when multiple flags provided

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/cli.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/cli.py
@@ -529,11 +529,8 @@ def cmd_record_application(args):
         print(json.dumps(_dry_run_skip(state, command="record-application", round=args.round)))
         return
 
-    if args.verify_push:
-        result = record_application_phase3(state, round_num=args.round)
-    elif args.commit_sha:
-        result = record_application_phase2(state, round_num=args.round, commit_sha=args.commit_sha)
-    elif args.applied_issues is not None:
+    result = None
+    if args.applied_issues is not None:
         try:
             applied = json.loads(args.applied_issues)
             failed = _normalize_failed_issues(args.failed_issues)
@@ -543,7 +540,14 @@ def cmd_record_application(args):
             state, round_num=args.round,
             applied_issue_ids=applied, failed_issue_ids=failed,
         )
-    else:
+
+    if args.commit_sha:
+        result = record_application_phase2(state, round_num=args.round, commit_sha=args.commit_sha)
+
+    if args.verify_push:
+        result = record_application_phase3(state, round_num=args.round)
+
+    if result is None:
         _error_exit("Must provide --applied-issues, --commit-sha, or --verify-push")
 
     save_state(state, args.state_file)

--- a/skills/cc-codex-debate-review/tests/test_cli.py
+++ b/skills/cc-codex-debate-review/tests/test_cli.py
@@ -851,6 +851,35 @@ def test_cli_record_application_accepts_failed_issue_objects(monkeypatch, capsys
     assert state["issues"][issue_id]["application_status"] == "failed"
 
 
+def test_cli_record_application_phase1_then_phase2(monkeypatch, capsys, state_path):
+    """When both --applied-issues and --commit-sha are provided, Phase 1 and Phase 2 run sequentially."""
+    _run_cli(monkeypatch, [
+        "upsert-issue", "--state-file", state_path,
+        "--agent", "codex", "--round", "1",
+        "--severity", "critical", "--criterion", "1",
+        "--file", "src/a.py", "--line", "10",
+        "--anchor", "validate_input",
+        "--message", "Missing input validation",
+    ])
+    issue_id = json.loads(capsys.readouterr().out)["issue_id"]
+
+    _run_cli(monkeypatch, [
+        "record-application", "--state-file", state_path,
+        "--round", "1",
+        "--applied-issues", json.dumps([issue_id]),
+        "--commit-sha", "deadbeef123",
+    ])
+    result = json.loads(capsys.readouterr().out)
+    # Phase 2 result is printed last
+    assert result["phase"] == 2
+    assert result["commit_sha"] == "deadbeef123"
+
+    # Phase 1 must have also run: application_status should be "applied"
+    state = load_state(state_path)
+    assert state["issues"][issue_id]["application_status"] == "applied"
+    assert state["journal"]["commit_sha"] == "deadbeef123"
+
+
 def test_cli_test_error_exits_with_json_error(monkeypatch, capsys):
     """test-error should raise RuntimeError → _error_exit → JSON error + exit 1."""
     monkeypatch.setattr(sys, "argv", ["debate-review", "test-error"])


### PR DESCRIPTION
## Summary
- record-application CLI now executes Phase 1→2→3 sequentially when multiple flags are provided
- Previously, elif chain caused Phase 1 to be skipped when --commit-sha was also present

## Test plan
- [ ] New test: both --applied-issues and --commit-sha triggers Phase 1 then Phase 2
- [ ] Existing tests pass

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)