### PR TITLE
docs(debate-review): update completion backlog status

### DIFF
--- a/docs/plans/2026-04-01-debate-review-persistent-agent-impl.md
+++ b/docs/plans/2026-04-01-debate-review-persistent-agent-impl.md
@@ -86,10 +86,10 @@
 
 `#170` (merged) — CLI 명령 구현, `#172` (open) — orchestrator 통합.
 
-- ~~`mark-failed` 후 GitHub issue 생성용 CLI 추가~~ → `create-failure-issue`
-- ~~final state 후 PR title 갱신용 CLI 추가~~ → `update-pr-status`
-- ~~worktree cleanup CLI 추가~~ → `cleanup-worktree`
-- orchestrator `_terminal()` / `_mark_failed()` / `_cleanup_worktree()` 연동은 `#172`에서 진행 중
+- ~~`mark-failed` 후 GitHub issue 생성용 CLI 추가~~ → `create-failure-issue` ✅
+- ~~final state 후 PR title 갱신용 CLI 추가~~ → `update-pr-status` ✅
+- ~~worktree cleanup CLI 추가~~ → `cleanup-worktree` ✅
+- ⏳ orchestrator `_terminal()` / `_mark_failed()` / `_cleanup_worktree()` 연동 → `#172` (open)
 - CI / runtime status 추적 → orchestrator의 checkpoint 시스템으로 대체
 
 ### Workstream D: E2E verification


### PR DESCRIPTION
## 해결하려는 문제

debate-review persistent agent 구현 계획 문서(`docs/plans/2026-04-01-debate-review-persistent-agent-impl.md`)의 backlog 상태가 실제 PR 진행 상황과 맞지 않았습니다.

- `#171`이 이미 merged인데 문서에서는 `open`으로 표기
- `#172`의 base branch가 `main`인데 `#171 대상`으로 잘못 기술
- Workstream B/C 완료 상태 표시가 실제 PR 상태와 불일치
- 우선순위 목록이 현재 진행 상황을 반영하지 못함

## 구현 내용

### Checkpoint 섹션 갱신
- `#169`, `#170`, `#171` 진행 기록 추가
- `#171`을 `merged`로 정확히 표기, `#172` 의존 관계 오기 수정

### Implemented Foundation 보강
- `follow_through.py`, `test_follow_through.py` 링크 추가

### Workstream 상태 정리
- **Workstream B** (orchestration path): `#171` merged 반영하여 ✅ 완료 처리
- **Workstream C** (follow-through): CLI 명령(`#170` merged) ✅, orchestrator 통합(`#172` open) ⏳ 분리 표기
- 하위 항목의 취소선 범위를 CLI 완료 부분과 orchestrator 미완 부분으로 분리

### 우선순위 목록 갱신
- 우선순위 3 (orchestration path) → ✅ 완료
- 우선순위 4 (follow-through 자동화) → `#172` open 상태 반영
- 불필요한 "참고" 섹션 제거

## 기대효과

- 문서를 읽는 사람이 현재 어디까지 완료되었고 무엇이 남았는지 정확하게 파악 가능
- `#172` (orchestrator 통합)가 유일한 미완 작업임이 명확하게 드러남
- Workstream 간 의존 관계 오해 방지

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)