### PR TITLE
feat(debate-review): CC agent를 claude -p subprocess로 전환 (Codex 대칭 구조)

### DIFF
--- a/skills/cc-codex-debate-review/SKILL.md
+++ b/skills/cc-codex-debate-review/SKILL.md
@@ -19,7 +19,7 @@ CC is the orchestrator. Both CC and Codex are invoked as sub-agents using the sa
 CC (orchestrator)
   ├─ $DEBATE_REVIEW_BIN <subcommand>  → state management (CLI)
   ├─ codex exec < agent-*.md          → Codex sub-agent (odd lead, even cross)
-  └─ CC Agent(prompt=agent-*.md)      → CC sub-agent (even lead, odd cross)
+  └─ claude -p < agent-*.md           → CC sub-agent (even lead, odd cross)
 ```
 
 ## When to Use
@@ -130,11 +130,20 @@ CODEX_PROMPT_FILE=$(echo "$INIT_RESULT" | jq -r '.prompt_file')
 Prompt files are persisted at `~/.claude/debate-state/prompts/{owner}-{repo}-{pr}-{agent}.md`. Each subsequent step appends to the same file.
 
 **CC Agent:**
+```bash
+CC_INIT_LOG=$(mktemp /tmp/debate-cc-init-XXXXXX)
+cd "$WORKTREE_PATH"
+claude -p --dangerously-skip-permissions --output-format stream-json --verbose \
+  < "$CC_PROMPT_FILE" | tee "$CC_INIT_LOG"
+CC_AGENT_ID=$(jq -r 'select(.type == "system" and .subtype == "init") | .session_id' "$CC_INIT_LOG" | head -n 1)
+if [ -z "$CC_AGENT_ID" ]; then
+  echo "Failed to capture CC_AGENT_ID from Claude Code JSON output" >&2
+  exit 1
+fi
+rm -f "$CC_INIT_LOG"
 ```
-FILLED_INITIAL_PROMPT=$(cat "$CC_PROMPT_FILE")
-Agent(prompt="$FILLED_INITIAL_PROMPT", description="debate-review CC agent")
-→ store CC_AGENT_ID
-```
+
+The `system/init` event is emitted at the start of `claude -p --output-format stream-json`; use its `session_id` as `CC_AGENT_ID` for later `--resume` calls.
 
 **Codex Agent:**
 ```bash
@@ -196,13 +205,13 @@ Is this a fresh session (STATUS=created)?
     Are both handles non-empty?
       NO → handles missing. Go to Recovery.
       YES → attempt first step dispatch with existing handles.
-            If SendMessage/resume fails → Go to Recovery.
+            If resume fails → Go to Recovery.
             If succeeds → Set AGENTS_READY=true.
 ```
 
 **Recovery**: Create replacement agent(s) using the recovery prompt from **Persistent Mode Restart** below. After creation, persist new IDs with `record-agent-sessions`. Set `AGENTS_READY=true`.
 
-Once `AGENTS_READY=true`, all subsequent step dispatches use `SendMessage`/`codex exec resume` for the remainder of the session.
+Once `AGENTS_READY=true`, all subsequent step dispatches use `claude -p --resume`/`codex exec resume` for the remainder of the session.
 
 ---
 
@@ -286,7 +295,7 @@ Skip if no previous round exists or no rebuttals are pending.
    - `OPEN_ISSUES_JSON`, `DEBATE_LEDGER_TEXT` → from `"$DEBATE_REVIEW_BIN" show --state-file "$STATE_FILE" --json`
    - `PENDING_REBUTTALS_JSON` → previous round Step 3 output, items where `decision=maintain`. If round 1, use `[]`. On restart/recovery when the previous agent output is unavailable, rebuild it from `show --json` using the previous round's `step3.rebuttals` plus `issues[*].reports` matched by `report_id`.
 2. Dispatch to lead agent:
-   - CC: `SendMessage(to=CC_AGENT_ID, message=step_message)`
+   - CC: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && claude -p --dangerously-skip-permissions --resume "$CC_AGENT_ID" --output-format json - < "$STEP_FILE"`
    - Codex: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && codex exec resume "$CODEX_SESSION_ID" - < "$STEP_FILE"`
 3. Parse JSON response (retry up to 3 times on failure)
 
@@ -391,7 +400,7 @@ The cross-verifier performs two tasks:
    - `LEAD_FINDINGS_JSON` → this round's Step 1 agent output (`findings` array verbatim). On restart/recovery when that output is unavailable, rebuild it from `show --json` using the current round's `step1.report_ids` plus `issues[*].reports` matched by `report_id`.
    - `DEBATE_LEDGER_TEXT` → from `"$DEBATE_REVIEW_BIN" show --state-file "$STATE_FILE" --json`
 2. Dispatch to cross-verifier agent:
-   - CC: `SendMessage(to=CC_AGENT_ID, message=step_message)`
+   - CC: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && claude -p --dangerously-skip-permissions --resume "$CC_AGENT_ID" --output-format json - < "$STEP_FILE"`
    - Codex: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && codex exec resume "$CODEX_SESSION_ID" - < "$STEP_FILE"`
 3. Parse JSON response (retry up to 3 times on failure)
 
@@ -466,7 +475,7 @@ The lead agent edits files directly in the worktree, commits, and pushes. There 
    - `APPLICABLE_ISSUES_JSON` → from `show --json`, filtered: `consensus_status=accepted` AND `application_status in (pending, failed)`. Empty `[]` when `IS_FORK=true` or `DRY_RUN=true`.
    - Include `WORKTREE_PATH`, `DEBATE_REVIEW_BIN`, `STATE_FILE`, `HEAD_BRANCH`, `ROUND` literals in the message.
 2. Dispatch to lead agent:
-   - CC: `SendMessage(to=CC_AGENT_ID, message=step_message)`
+   - CC: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && claude -p --dangerously-skip-permissions --resume "$CC_AGENT_ID" --output-format json - < "$STEP_FILE"`
    - Codex: write `$step_message` to a temp file, then `cd "$WORKTREE_PATH" && codex exec resume "$CODEX_SESSION_ID" - < "$STEP_FILE"`
 3. Parse JSON response (retry up to 3 times on failure)
 
@@ -716,9 +725,9 @@ The `resume_context` object provides additional details (e.g., `clean_pass`, `co
 When `AGENT_MODE=persistent` and a session is resumed:
 
 - Load `persistent_agents.cc_agent_id` / `persistent_agents.codex_session_id` from the state file (or `show --json`) first.
-- **Agent still alive** (persisted handle exists and SendMessage/resume succeeds): Continue from the journal step with the existing agent. No special recovery needed.
+- **Agent still alive** (persisted handle exists and resume succeeds): Continue from the journal step with the existing agent. No special recovery needed.
 - **Missing handle** (`persistent_agents` field absent or either ID is null): Treat as agent dead and go to recovery immediately.
-- **Agent dead** (SendMessage/resume fails): Create a new agent with a recovery prompt that includes the debate state so far:
+- **Agent dead** (resume fails): Create a new agent with a recovery prompt that includes the debate state so far:
 
 ```markdown
 # Debate Review Agent (Recovered): {REPO} #{PR_NUMBER}
@@ -796,8 +805,12 @@ rm -f "$PROMPT_FILE"
 ```
 
 **CC sub-agent:**
-```
-Agent(prompt="$FILLED_PROMPT", description="debate-review step N")
+```bash
+cd "$WORKTREE_PATH"
+PROMPT_FILE=$(mktemp /tmp/debate-prompt-XXXXXX)
+printf '%s' "$FILLED_PROMPT" > "$PROMPT_FILE"
+claude -p --dangerously-skip-permissions --output-format json < "$PROMPT_FILE"
+rm -f "$PROMPT_FILE"
 ```
 
 #### Legacy Placeholder Derivation
@@ -821,11 +834,10 @@ The CLI returns `prompt_file` (cumulative) and `message_file` (this step only). 
 
 **CC Agent dispatch:**
 ```bash
-STEP_MESSAGE=$(cat "$MSG_FILE")
-SendMessage(to=CC_AGENT_ID, message=STEP_MESSAGE)
+cd "$WORKTREE_PATH"
+claude -p --dangerously-skip-permissions --resume "$CC_AGENT_ID" --output-format json < "$MSG_FILE"
 rm -f "$MSG_FILE"
 ```
-Requires: `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
 
 **Codex Agent dispatch:**
 ```bash

--- a/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
@@ -166,6 +166,44 @@ class CodexAdapter(AgentAdapter):
         )
 
 
+def _unwrap_cc_result(output: str) -> dict:
+    """Unwrap Claude Code --output-format json wrapper to extract agent response.
+
+    Claude Code wraps the agent's text in {"type":"result","result":"<json-string>",...}.
+    """
+    wrapper = _parse_json_object(output)
+    if wrapper.get("type") == "result" and "result" in wrapper:
+        inner = wrapper["result"]
+        if isinstance(inner, str):
+            try:
+                parsed = json.loads(inner)
+                if isinstance(parsed, dict):
+                    return parsed
+            except json.JSONDecodeError:
+                pass
+    return wrapper
+
+
+class CcAdapter(AgentAdapter):
+    def __init__(self):
+        super().__init__(
+            name="cc",
+            legacy_command="claude -p --dangerously-skip-permissions --output-format json",
+            create_command="claude -p --dangerously-skip-permissions --output-format stream-json --verbose",
+            send_command="claude -p --dangerously-skip-permissions --resume {session_id} --output-format json",
+        )
+
+    def run_legacy(self, prompt: str, *, worktree_path: str, sandbox: str) -> dict:
+        command = self._format(self.legacy_command, sandbox=sandbox)
+        output = _run_command(command, cwd=worktree_path, stdin_text=prompt)
+        return _unwrap_cc_result(output)
+
+    def send_message(self, session_id: str, message: str, *, worktree_path: str) -> dict:
+        command = self._format(self.send_command, session_id=session_id)
+        output = _run_command(command, cwd=worktree_path, stdin_text=message)
+        return _unwrap_cc_result(output)
+
+
 class SubprocessDebateCli:
     def __init__(self, debate_review_bin: str):
         self.debate_review_bin = debate_review_bin
@@ -1035,12 +1073,12 @@ def _build_adapters(config: dict) -> dict[str, AgentAdapter]:
     def _from_cfg(name: str, defaults: AgentAdapter | None = None) -> AgentAdapter:
         cfg = agent_cfg.get(name, {}) if isinstance(agent_cfg, dict) else {}
         if defaults is not None:
-            return AgentAdapter(
-                name=name,
-                legacy_command=cfg.get("legacy_command", defaults.legacy_command),
-                create_command=cfg.get("persistent_create_command", defaults.create_command),
-                send_command=cfg.get("persistent_send_command", defaults.send_command),
-            )
+            if not cfg:
+                return defaults
+            defaults.legacy_command = cfg.get("legacy_command", defaults.legacy_command)
+            defaults.create_command = cfg.get("persistent_create_command", defaults.create_command)
+            defaults.send_command = cfg.get("persistent_send_command", defaults.send_command)
+            return defaults
         return AgentAdapter(
             name=name,
             legacy_command=cfg.get("legacy_command"),
@@ -1050,7 +1088,7 @@ def _build_adapters(config: dict) -> dict[str, AgentAdapter]:
 
     adapters = {
         "codex": _from_cfg("codex", defaults=CodexAdapter()),
-        "cc": _from_cfg("cc"),
+        "cc": _from_cfg("cc", defaults=CcAdapter()),
     }
     for name, adapter in adapters.items():
         _validate_runtime_commands(agent_name=name, agent_mode=agent_mode, adapter=adapter)

--- a/skills/cc-codex-debate-review/tests/test_orchestrator.py
+++ b/skills/cc-codex-debate-review/tests/test_orchestrator.py
@@ -520,13 +520,16 @@ def test_follow_through_errors_do_not_propagate(monkeypatch, tmp_path):
     assert result["result"] == "consensus_reached"
 
 
-def test_build_adapters_requires_cc_commands_in_persistent_mode():
-    from debate_review.orchestrator import OrchestrationError, _build_adapters
+def test_build_adapters_cc_has_default_commands_in_persistent_mode():
+    from debate_review.orchestrator import CcAdapter, _build_adapters
 
     config = {"agent_mode": "persistent"}
 
-    with pytest.raises(OrchestrationError, match="cc runtime commands are not configured"):
-        _build_adapters(config)
+    adapters = _build_adapters(config)
+    cc = adapters["cc"]
+    assert isinstance(cc, CcAdapter)
+    assert cc.create_command is not None
+    assert cc.send_command is not None
 
 
 def test_terminal_still_runs_follow_through_when_post_comment_fails(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- CC agent를 Orchestrator 내부 `Agent()` tool 대신 `claude -p` CLI subprocess로 invoke하도록 변경
- `CcAdapter` 클래스 추가로 Codex adapter와 완전 대칭적 구조 달성
- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 환경변수 의존성 완전 제거

## Motivation

E2E 테스트에서 CC agent의 persistent mode `SendMessage`가 동작하지 않음을 확인. 원인은 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 환경변수가 Orchestrator 프로세스에 설정되지 않았기 때문. Orchestrator는 자기 프로세스의 환경변수를 제어할 수 없으므로, CC도 Codex처럼 CLI subprocess로 전환.

## Changes

| File | Change |
|------|--------|
| `orchestrator.py` | `CcAdapter` 추가, `_unwrap_cc_result()` 추가, `_from_cfg()` subclass 보존, `_build_adapters()` CC 기본 adapter 적용 |
| `SKILL.md` | `SendMessage`/`Agent()` → `claude -p --resume` 교체 |
| `test_orchestrator.py` | CC commands 미설정 에러 테스트 → CC 기본 adapter 존재 확인 테스트 |

## CC ↔ Codex 대칭 구조

| 동작 | Codex | CC |
|------|-------|----|
| Legacy | `codex exec -s danger-full-access -` | `claude -p --dangerously-skip-permissions --output-format json` |
| Create | `codex exec --json -s danger-full-access -` | `claude -p --dangerously-skip-permissions --output-format stream-json --verbose` |
| Resume | `codex exec resume {session_id} -` | `claude -p --dangerously-skip-permissions --resume {session_id} --output-format json` |
| Session ID | `thread.started → thread_id` | `system/init → session_id` |

## Test plan

- [x] `pytest tests/test_orchestrator.py` — 12 passed
- [x] `pytest tests/` — 263 passed
- [x] `claude -p --resume` + stdin 동작 검증 완료
- [x] `--dangerously-skip-permissions` → `permissionMode: bypassPermissions` 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)