### PR TITLE
fix(debate-review): update_pr_status 기능 완전 제거

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/cli.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/cli.py
@@ -23,7 +23,7 @@ from debate_review.round_ops import init_round, record_verdict, settle_round
 from debate_review.comment import post_comment
 from debate_review.sync import sync_head
 from debate_review.error_log import save_error_log
-from debate_review.follow_through import create_failure_issue, update_pr_status, cleanup_worktree
+from debate_review.follow_through import create_failure_issue, cleanup_worktree
 from debate_review.state import (
     append_ledger,
     StateCorruptedError,
@@ -171,10 +171,6 @@ def build_parser() -> argparse.ArgumentParser:
     # create-failure-issue subcommand
     p_cfi = subparsers.add_parser("create-failure-issue", help="Create GitHub issue on failure/stall")
     p_cfi.add_argument("--state-file", required=True)
-
-    # update-pr-status subcommand
-    p_ups = subparsers.add_parser("update-pr-status", help="Add debate result label to PR title")
-    p_ups.add_argument("--state-file", required=True)
 
     # cleanup-worktree subcommand
     p_cw = subparsers.add_parser("cleanup-worktree", help="Remove debate worktree")
@@ -696,14 +692,6 @@ def cmd_create_failure_issue(args):
     print(json.dumps(result))
 
 
-def cmd_update_pr_status(args):
-    state = load_state(args.state_file)
-    if state is None:
-        _error_exit(f"No state file found at {args.state_file}")
-    result = update_pr_status(state)
-    print(json.dumps(result))
-
-
 def cmd_cleanup_worktree(args):
     state = load_state(args.state_file)
     if state is None:
@@ -775,7 +763,6 @@ def main():
         "build-prompt": cmd_build_prompt,
         "report-sessions": cmd_report_sessions,
         "create-failure-issue": cmd_create_failure_issue,
-        "update-pr-status": cmd_update_pr_status,
         "cleanup-worktree": cmd_cleanup_worktree,
         "test-error": cmd_test_error,
         "mark-failed": cmd_mark_failed,

--- a/skills/cc-codex-debate-review/lib/debate_review/follow_through.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/follow_through.py
@@ -2,22 +2,12 @@
 
 import json
 import os
-import re
 import subprocess
 
-from debate_review.gh import gh, gh_json
+from debate_review.gh import gh
 
-
-_OUTCOME_LABELS = {
-    "consensus": "[debate: consensus]",
-    "no_consensus": "[debate: no consensus]",
-    "error": "[debate: failed]",
-    "stalled": "[debate: stalled]",
-}
 
 _FAILURE_OUTCOMES = {"error", "stalled"}
-
-_DEBATE_LABEL_RE = re.compile(r"\[debate: [^\]]+\]\s*")
 
 
 def create_failure_issue(state, *, _gh=None) -> dict:
@@ -60,51 +50,6 @@ def create_failure_issue(state, *, _gh=None) -> dict:
         return {"action": "error", "reason": f"Failed to create issue: {e}"}
 
     return {"action": "created", "url": raw.strip()}
-
-
-def update_pr_status(state, *, _gh=None, _gh_json=None) -> dict:
-    """Add a debate result label to the PR title."""
-    outcome = state.get("final_outcome")
-    label = _OUTCOME_LABELS.get(outcome)
-    if label is None:
-        return {"action": "skipped", "reason": "not terminal"}
-
-    if state.get("dry_run"):
-        return {"action": "dry_run", "label": label}
-
-    repo = state["repo"]
-    pr_number = state["pr_number"]
-
-    gh_json_fn = _gh_json or gh_json
-    try:
-        pr_data = gh_json_fn(
-            "pr", "view", str(pr_number),
-            "--repo", repo,
-            "--json", "title",
-        )
-    except RuntimeError as e:
-        return {"action": "error", "reason": f"Failed to fetch PR title: {e}"}
-
-    current_title = pr_data.get("title", "")
-
-    if label in current_title:
-        return {"action": "skipped", "reason": "already labeled", "label": label}
-
-    # Strip any existing debate label before adding the new one
-    stripped_title = _DEBATE_LABEL_RE.sub("", current_title)
-    new_title = f"{label} {stripped_title}"
-
-    gh_fn = _gh or gh
-    try:
-        gh_fn(
-            "pr", "edit", str(pr_number),
-            "--repo", repo,
-            "--title", new_title,
-        )
-    except RuntimeError as e:
-        return {"action": "error", "reason": f"Failed to update PR title: {e}"}
-
-    return {"action": "updated", "label": label, "title": new_title}
 
 
 def cleanup_worktree(state, *, _remove_worktree=None) -> dict:

--- a/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
@@ -424,9 +424,6 @@ class SubprocessDebateCli:
     def create_failure_issue(self, state_file: str) -> dict:
         return self._run_json("create-failure-issue", "--state-file", state_file)
 
-    def update_pr_status(self, state_file: str) -> dict:
-        return self._run_json("update-pr-status", "--state-file", state_file)
-
     def build_prompt(self, state_file: str, *, agent: str, step: str, round_num: int | None = None, extra: str | None = None) -> dict:
         args = [
             "build-prompt",
@@ -1120,11 +1117,7 @@ class DebateReviewOrchestrator:
         return "step1"
 
     def _follow_through(self, state: dict) -> None:
-        """Best-effort follow-through: update PR status and create failure issues."""
-        try:
-            self.cli.update_pr_status(self.state_file)
-        except Exception:
-            pass
+        """Best-effort follow-through: create failure issues on error/stall."""
         if state.get("final_outcome") in ("error", "stalled"):
             try:
                 self.cli.create_failure_issue(self.state_file)

--- a/skills/cc-codex-debate-review/tests/test_follow_through.py
+++ b/skills/cc-codex-debate-review/tests/test_follow_through.py
@@ -8,7 +8,6 @@ from debate_review.state import create_initial_state, save_state
 from debate_review.cli import main
 from debate_review.follow_through import (
     create_failure_issue,
-    update_pr_status,
     cleanup_worktree,
 )
 
@@ -146,152 +145,6 @@ class TestCreateFailureIssue:
         assert "#42" in title
 
 
-# --- update_pr_status ---
-
-class TestUpdatePrStatus:
-    def _mock_gh_json_title(self, title="Fix stuff"):
-        def mock(*args):
-            return {"title": title}
-        return mock
-
-    def test_consensus_adds_label(self):
-        state = _consensus_state()
-        edited = []
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=self._mock_gh_json_title())
-        assert result["action"] == "updated"
-        assert result["label"] == "[debate: consensus]"
-        args = edited[0]
-        assert "pr" in args
-        assert "edit" in args
-
-    def test_failed_adds_label(self):
-        state = _failed_state()
-        edited = []
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=self._mock_gh_json_title())
-        assert result["action"] == "updated"
-        assert result["label"] == "[debate: failed]"
-
-    def test_max_rounds_adds_label(self):
-        state = _max_rounds_state()
-        edited = []
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=self._mock_gh_json_title())
-        assert result["action"] == "updated"
-        assert result["label"] == "[debate: no consensus]"
-
-    def test_stalled_adds_label(self):
-        state = _stalled_state()
-        edited = []
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=self._mock_gh_json_title())
-        assert result["action"] == "updated"
-        assert result["label"] == "[debate: stalled]"
-
-    def test_in_progress_skips(self):
-        state = create_initial_state(
-            repo="owner/repo", repo_root="/tmp/repo", pr_number=42,
-            is_fork=False, head_sha="abc1234def5678",
-            pr_branch_name="feat/test", max_rounds=10,
-        )
-        result = update_pr_status(state)
-        assert result["action"] == "skipped"
-        assert "not terminal" in result["reason"]
-
-    def test_dry_run_skips(self):
-        state = _consensus_state()
-        state["dry_run"] = True
-        result = update_pr_status(state)
-        assert result["action"] == "dry_run"
-
-    def test_does_not_duplicate_label(self):
-        """If title already has the label, skip."""
-        state = _consensus_state()
-
-        def mock_gh_json(*args):
-            return {"title": "[debate: consensus] Fix stuff"}
-
-        result = update_pr_status(state, _gh_json=mock_gh_json)
-        assert result["action"] == "skipped"
-        assert "already" in result["reason"]
-
-    def test_edits_title_via_gh(self):
-        state = _consensus_state()
-        edited = []
-
-        def mock_gh_json(*args):
-            return {"title": "Fix stuff"}
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=mock_gh_json)
-        assert result["action"] == "updated"
-        args = edited[0]
-        title_idx = list(args).index("--title") + 1
-        assert args[title_idx] == "[debate: consensus] Fix stuff"
-
-    def test_strips_old_label_before_adding_new(self):
-        """If title already has a different debate label, strip it first."""
-        state = _consensus_state()
-        edited = []
-
-        def mock_gh_json(*args):
-            return {"title": "[debate: failed] Fix stuff"}
-
-        def mock_gh(*args):
-            edited.append(args)
-            return ""
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=mock_gh_json)
-        assert result["action"] == "updated"
-        args = edited[0]
-        title_idx = list(args).index("--title") + 1
-        assert args[title_idx] == "[debate: consensus] Fix stuff"
-        assert "[debate: failed]" not in args[title_idx]
-
-    def test_gh_json_failure_returns_error(self):
-        state = _consensus_state()
-
-        def mock_gh_json(*args):
-            raise RuntimeError("GraphQL: not found")
-
-        result = update_pr_status(state, _gh_json=mock_gh_json)
-        assert result["action"] == "error"
-        assert "Failed to fetch PR title" in result["reason"]
-
-    def test_gh_edit_failure_returns_error(self):
-        state = _consensus_state()
-
-        def mock_gh_json(*args):
-            return {"title": "Fix stuff"}
-
-        def mock_gh(*args):
-            raise RuntimeError("GraphQL: Resource not accessible")
-
-        result = update_pr_status(state, _gh=mock_gh, _gh_json=mock_gh_json)
-        assert result["action"] == "error"
-        assert "Failed to update PR title" in result["reason"]
-
-
 # --- cleanup_worktree ---
 
 class TestCleanupWorktree:
@@ -389,17 +242,6 @@ class TestCLIFollowThrough:
         _run_cli(monkeypatch, ["create-failure-issue", "--state-file", path])
         out = json.loads(capsys.readouterr().out)
         assert out["action"] == "dry_run"
-
-    def test_update_pr_status_cli_dry_run(self, monkeypatch, capsys, tmp_path):
-        state = _consensus_state()
-        state["dry_run"] = True
-        path = str(tmp_path / "state.json")
-        save_state(state, path)
-
-        _run_cli(monkeypatch, ["update-pr-status", "--state-file", path])
-        out = json.loads(capsys.readouterr().out)
-        assert out["action"] == "dry_run"
-        assert out["label"] == "[debate: consensus]"
 
     def test_cleanup_worktree_cli_not_exists(self, monkeypatch, capsys, tmp_path):
         state = create_initial_state(

--- a/skills/cc-codex-debate-review/tests/test_orchestrator.py
+++ b/skills/cc-codex-debate-review/tests/test_orchestrator.py
@@ -30,7 +30,6 @@ class FakeCli:
         self.build_prompt_calls = []
         self.record_step_trace_calls = []
         self.create_failure_issue_calls = []
-        self.update_pr_status_calls = []
 
     def init_session(self, **_kwargs):
         result = {
@@ -147,10 +146,6 @@ class FakeCli:
         if outcome not in ("error", "stalled"):
             return {"action": "skipped", "reason": "not failed"}
         return {"action": "created", "url": "https://github.com/owner/repo/issues/99"}
-
-    def update_pr_status(self, _state_file):
-        self.update_pr_status_calls.append(True)
-        return {"action": "updated", "label": "[debate: consensus]"}
 
     def build_prompt(self, _state_file, *, agent, step, round_num=None, extra=None):
         self.build_prompt_calls.append((agent, step, round_num, extra))
@@ -522,39 +517,8 @@ def test_orchestrator_marks_failed_and_posts_comment_on_dispatch_error(monkeypat
     assert cli.state["status"] == "failed"
 
 
-def test_terminal_calls_update_pr_status(monkeypatch, tmp_path):
-    """_terminal() should call update_pr_status after post_comment."""
-    import debate_review.orchestrator as orchestrator_module
-
-    checkpoint_path = tmp_path / "checkpoint.json"
-    monkeypatch.setattr(orchestrator_module, "_checkpoint_path", lambda _state_file: str(checkpoint_path))
-
-    state = _sample_state(agent_mode="legacy")
-    cli = FakeCli(state, state_file=str(tmp_path / "state.json"))
-    codex = ScriptedAdapter(
-        "codex",
-        legacy=[{"rebuttal_responses": [], "withdrawals": [], "findings": [], "verdict": "no_findings_mergeable"}],
-    )
-    cc = ScriptedAdapter(
-        "cc",
-        legacy=[{"rebuttal_responses": [], "withdrawals": [], "findings": [], "verdict": "no_findings_mergeable"}],
-    )
-
-    orchestrator = DebateReviewOrchestrator(
-        cli=cli,
-        adapters={"codex": codex, "cc": cc},
-        skill_root=SKILL_ROOT,
-        config={"codex_sandbox": "danger-full-access"},
-        cleanup_worktree=False,
-    )
-
-    orchestrator.run(repo="owner/repo", pr_number=123)
-
-    assert cli.update_pr_status_calls == [True]
-
-
-def test_mark_failed_calls_create_failure_issue_and_update_pr_status(monkeypatch, tmp_path):
-    """_mark_failed() should call create_failure_issue and update_pr_status."""
+def test_mark_failed_calls_create_failure_issue(monkeypatch, tmp_path):
+    """_mark_failed() should call create_failure_issue."""
     import debate_review.orchestrator as orchestrator_module
 
     checkpoint_path = tmp_path / "checkpoint.json"
@@ -579,7 +543,6 @@ def test_mark_failed_calls_create_failure_issue_and_update_pr_status(monkeypatch
         orchestrator.run(repo="owner/repo", pr_number=123)
 
     assert cli.create_failure_issue_calls == [True]
-    assert cli.update_pr_status_calls == [True]
 
 
 def test_follow_through_errors_do_not_propagate(monkeypatch, tmp_path):
@@ -593,10 +556,10 @@ def test_follow_through_errors_do_not_propagate(monkeypatch, tmp_path):
     cli = FakeCli(state, state_file=str(tmp_path / "state.json"))
 
     # Override follow-through to raise
-    def exploding_update(_state_file):
+    def exploding_create(_state_file):
         raise RuntimeError("gh API down")
 
-    cli.update_pr_status = exploding_update
+    cli.create_failure_issue = exploding_create
 
     codex = ScriptedAdapter(
         "codex",
@@ -666,7 +629,6 @@ def test_terminal_still_runs_follow_through_when_post_comment_fails(monkeypatch,
     with pytest.raises(RuntimeError, match="comment failed"):
         orchestrator.run(repo="owner/repo", pr_number=123)
 
-    assert cli.update_pr_status_calls
     assert cli.mark_failed_calls == []
     assert cli.state["status"] == "consensus_reached"
 
@@ -702,7 +664,6 @@ def test_mark_failed_still_runs_follow_through_when_post_comment_fails(monkeypat
         orchestrator.run(repo="owner/repo", pr_number=123)
 
     assert cli.create_failure_issue_calls == [True]
-    assert cli.update_pr_status_calls == [True]
 
 
 def test_terminal_cleanup_failure_does_not_override_terminal_result(monkeypatch, tmp_path):
@@ -740,7 +701,6 @@ def test_terminal_cleanup_failure_does_not_override_terminal_result(monkeypatch,
     assert result["result"] == "consensus_reached"
     assert cli.state["final_outcome"] == "consensus"
     assert cli.state["status"] == "consensus_reached"
-    assert cli.update_pr_status_calls == [True]
 
 
 def test_cleanup_worktree_skips_dry_run(monkeypatch, tmp_path):


### PR DESCRIPTION
## 문제현상

debate-review 종료 시 `update_pr_status`가 PR title 앞에 `[debate: consensus]`, `[debate: failed]` 등의 label prefix를 자동으로 붙임. 외부 repo(querypie/querypie-docs#979)의 PR 제목까지 임의 변경하는 사고 발생.

## 구현내용

- `follow_through.py`: `update_pr_status()` 함수, `_OUTCOME_LABELS`, `_DEBATE_LABEL_RE` 제거
- `cli.py`: `update-pr-status` subcommand 제거
- `orchestrator.py`: `_follow_through()`에서 `update_pr_status` 호출 제거, `SubprocessDebateCli.update_pr_status()` 메서드 제거
- `test_follow_through.py`: `TestUpdatePrStatus` 클래스 및 CLI integration test 제거
- `test_orchestrator.py`: `FakeCli.update_pr_status` 및 관련 assertions 제거

정규화 코드(`_extract_json_from_text`, `_normalize_cross_verifications`, `_normalize_withdrawals`)는 PR #183에서 별도로 다룹니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)