### PR TITLE
fix(debate-review): 오케스트레이터 에이전트 응답 정규화 강화

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
@@ -296,6 +296,12 @@ def _normalize_withdrawals(withdrawals: list) -> list:
     return normalized
 
 
+def _is_non_owner_withdrawal_error(exc: OrchestrationError) -> bool:
+    """Return True only for the expected 'wrong owner' withdrawal failure."""
+    message = str(exc).lower()
+    return "cannot withdraw" in message and "opened by" in message
+
+
 class CcAdapter(AgentAdapter):
     def __init__(self):
         super().__init__(
@@ -1005,8 +1011,9 @@ class DebateReviewOrchestrator:
                     round_num=round_ctx["round"],
                     reason=item.get("reason", ""),
                 )
-            except OrchestrationError:
-                pass  # agent requested invalid withdrawal (e.g. not owner); skip
+            except OrchestrationError as exc:
+                if not _is_non_owner_withdrawal_error(exc):
+                    raise
             checkpoint["progress"]["withdrawals_done"] += 1
             self._save_checkpoint(checkpoint)
 
@@ -1053,8 +1060,9 @@ class DebateReviewOrchestrator:
                     round_num=round_ctx["round"],
                     reason=item.get("reason", ""),
                 )
-            except OrchestrationError:
-                pass  # agent requested invalid withdrawal; skip
+            except OrchestrationError as exc:
+                if not _is_non_owner_withdrawal_error(exc):
+                    raise
             checkpoint["progress"]["withdrawals_done"] += 1
             self._save_checkpoint(checkpoint)
 
@@ -1086,8 +1094,9 @@ class DebateReviewOrchestrator:
                     round_num=round_ctx["round"],
                     reason=item.get("reason", ""),
                 )
-            except OrchestrationError:
-                pass  # agent requested invalid withdrawal; skip
+            except OrchestrationError as exc:
+                if not _is_non_owner_withdrawal_error(exc):
+                    raise
             checkpoint["progress"]["withdrawals_done"] += 1
             self._save_checkpoint(checkpoint)
 

--- a/skills/cc-codex-debate-review/tests/test_orchestrator.py
+++ b/skills/cc-codex-debate-review/tests/test_orchestrator.py
@@ -11,7 +11,7 @@ from debate_review.application import (
 )
 from debate_review.cross_verification import record_cross_verification, resolve_rebuttals
 from debate_review.issue_ops import upsert_issue, withdraw_issue
-from debate_review.orchestrator import DebateReviewOrchestrator
+from debate_review.orchestrator import DebateReviewOrchestrator, OrchestrationError
 from debate_review.round_ops import init_round, record_verdict, settle_round
 from debate_review.state import create_initial_state, mark_failed
 
@@ -492,6 +492,133 @@ def test_route_step3_checkpoint_resumes_remaining_phases(monkeypatch, tmp_path):
     ]
     assert cli.state["issues"]["isu_001"]["application_commit_sha"] == "deadbeef"
     assert not checkpoint_path.exists()
+
+
+def test_route_step1_checkpoint_ignores_non_owner_withdrawal_error(monkeypatch, tmp_path):
+    import debate_review.orchestrator as orchestrator_module
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    monkeypatch.setattr(orchestrator_module, "_checkpoint_path", lambda _state_file: str(checkpoint_path))
+
+    state = _sample_state(agent_mode="legacy")
+    init_round(state, round_num=1, synced_head_sha=state["head"]["last_observed_pr_sha"])
+    issue = upsert_issue(
+        state,
+        agent="cc",
+        round_num=1,
+        severity="warning",
+        criterion=6,
+        file="src/app.py",
+        line=1,
+        anchor="line1",
+        message="unused variable x",
+    )
+
+    class WrappingCli(FakeCli):
+        def withdraw_issue(self, _state_file, *, issue_id, agent, round_num, reason):
+            try:
+                return super().withdraw_issue(
+                    _state_file,
+                    issue_id=issue_id,
+                    agent=agent,
+                    round_num=round_num,
+                    reason=reason,
+                )
+            except ValueError as exc:
+                raise OrchestrationError(str(exc))
+
+    cli = WrappingCli(state, state_file=str(tmp_path / "state.json"))
+    orchestrator = DebateReviewOrchestrator(
+        cli=cli,
+        adapters={"codex": ScriptedAdapter("codex"), "cc": ScriptedAdapter("cc")},
+        skill_root=SKILL_ROOT,
+        config={"codex_sandbox": "danger-full-access"},
+        cleanup_worktree=False,
+    )
+    orchestrator.state_file = cli.state_file
+
+    checkpoint = {
+        "step": "step1",
+        "round": 1,
+        "agent": "codex",
+        "response": {
+            "rebuttal_responses": [],
+            "withdrawals": [{"issue_id": issue["issue_id"], "reason": "not mine"}],
+            "findings": [],
+            "verdict": "has_findings",
+        },
+        "progress": {
+            "rebuttals_done": False,
+            "withdrawals_done": 0,
+            "findings_done": 0,
+            "verdict_done": False,
+        },
+    }
+
+    next_step = orchestrator._route_step1_checkpoint(checkpoint, {
+        "round": 1,
+        "lead_agent": "codex",
+        "cross_verifier": "cc",
+        "worktree_path": "/tmp/repo/.worktrees/debate-pr-123",
+        "head_branch": "feat/test",
+    })
+
+    assert next_step == "step2"
+    assert checkpoint["progress"]["withdrawals_done"] == 1
+    assert cli.state["issues"][issue["issue_id"]]["consensus_status"] == "open"
+
+
+def test_route_step1_checkpoint_raises_on_unexpected_withdrawal_error(monkeypatch, tmp_path):
+    import debate_review.orchestrator as orchestrator_module
+
+    checkpoint_path = tmp_path / "checkpoint.json"
+    monkeypatch.setattr(orchestrator_module, "_checkpoint_path", lambda _state_file: str(checkpoint_path))
+
+    state = _sample_state(agent_mode="legacy")
+    init_round(state, round_num=1, synced_head_sha=state["head"]["last_observed_pr_sha"])
+
+    class FailingCli(FakeCli):
+        def withdraw_issue(self, _state_file, *, issue_id, agent, round_num, reason):
+            raise OrchestrationError(f"Unknown issue ID: {issue_id}")
+
+    cli = FailingCli(state, state_file=str(tmp_path / "state.json"))
+    orchestrator = DebateReviewOrchestrator(
+        cli=cli,
+        adapters={"codex": ScriptedAdapter("codex"), "cc": ScriptedAdapter("cc")},
+        skill_root=SKILL_ROOT,
+        config={"codex_sandbox": "danger-full-access"},
+        cleanup_worktree=False,
+    )
+    orchestrator.state_file = cli.state_file
+
+    checkpoint = {
+        "step": "step1",
+        "round": 1,
+        "agent": "codex",
+        "response": {
+            "rebuttal_responses": [],
+            "withdrawals": [{"issue_id": "isu_999", "reason": "broken"}],
+            "findings": [],
+            "verdict": "has_findings",
+        },
+        "progress": {
+            "rebuttals_done": False,
+            "withdrawals_done": 0,
+            "findings_done": 0,
+            "verdict_done": False,
+        },
+    }
+
+    with pytest.raises(OrchestrationError, match="Unknown issue ID: isu_999"):
+        orchestrator._route_step1_checkpoint(checkpoint, {
+            "round": 1,
+            "lead_agent": "codex",
+            "cross_verifier": "cc",
+            "worktree_path": "/tmp/repo/.worktrees/debate-pr-123",
+            "head_branch": "feat/test",
+        })
+
+    assert checkpoint["progress"]["withdrawals_done"] == 0
 
 
 def test_orchestrator_marks_failed_and_posts_comment_on_dispatch_error(monkeypatch, tmp_path):


### PR DESCRIPTION
## 문제현상

chequer-io/deck#783 대상 E2E 검증에서 오케스트레이터가 에이전트 응답 형식 불일치로 4곳에서 크래시 발생:

1. `KeyError: 'verdict'` — CC agent가 prose+markdown 코드블록으로 JSON 반환 시 파싱 실패
2. `OrchestrationError: cannot withdraw` — 에이전트가 다른 에이전트의 이슈를 withdraw 시도 시 fatal error
3. `KeyError: 'report_id'` — cross-verification에서 `issue_id`/`verdict` 사용 시 `report_id`/`decision` 기대
4. `TypeError: string indices` — withdrawal이 문자열 배열로 올 때 dict 접근 실패

## 구현내용

오케스트레이터에 4개의 정규화/방어 함수 추가:

- `_extract_json_from_text()`: 일반 JSON, markdown 코드블록, prose 속 코드블록 모두 처리
- `_normalize_cross_verifications()`: `issue_id→report_id`, `verdict→decision` 필드명 변환
- `_normalize_withdrawals()`: 문자열/dict 혼합 배열을 통일된 dict 배열로 변환
- `_is_non_owner_withdrawal_error()`: 3곳의 `withdraw_issue` 호출에서 소유권 오류만 선별 무시, 그 외 `OrchestrationError`는 재발생시켜 상태 불일치 방지

## 검증

- 단위 테스트 14개 추가 (28 passed)
- chequer-io/deck#783 대상 E2E 완주: Round 2 consensus 도달

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>