### PR TITLE
fix(debate-review): checkpoint 복구를 실패 상태에만 허용하고 stale checkpoint 방지

### DIFF
--- a/skills/cc-codex-debate-review/lib/debate_review/cli.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/cli.py
@@ -345,7 +345,7 @@ def cmd_init(args):
         existing_sha = existing["head"].get("terminal_sha") or existing["head"]["last_observed_pr_sha"]
         if existing_sha == head_sha:
             checkpoint_path = _orchestrator_checkpoint_path(state_path)
-            if os.path.exists(checkpoint_path):
+            if os.path.exists(checkpoint_path) and existing["status"] in ("failed",):
                 existing["status"] = "in_progress"
                 existing["final_outcome"] = None
                 existing["finished_at"] = None

--- a/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/orchestrator.py
@@ -1461,9 +1461,9 @@ class DebateReviewOrchestrator:
             comment_error = exc
 
         self._follow_through(state)
+        self._clear_checkpoint()
         if comment_error is not None:
             raise TerminalActionError(str(comment_error)) from comment_error
-        self._clear_checkpoint()
         try:
             self._cleanup_worktree(state)
         except Exception:

--- a/skills/cc-codex-debate-review/tests/test_cli.py
+++ b/skills/cc-codex-debate-review/tests/test_cli.py
@@ -833,6 +833,49 @@ def test_cli_init_failed_session_with_checkpoint_applies_resume_migrations(monke
     assert saved["rounds"][0]["step_traces"] == {}
 
 
+def test_cli_init_consensus_session_with_stale_checkpoint_rejects(monkeypatch, capsys, tmp_path):
+    """consensus_reached 세션은 stale checkpoint가 있어도 복구하지 않는다."""
+    state = create_initial_state(
+        repo="owner/repo",
+        repo_root="/tmp/repo",
+        pr_number=795,
+        is_fork=False,
+        head_sha="abc123",
+        pr_branch_name="feat/test",
+        agent_mode="persistent",
+    )
+    state["status"] = "consensus_reached"
+    state["final_outcome"] = "consensus"
+    state["finished_at"] = "2026-04-05T00:00:00+00:00"
+    state["head"]["terminal_sha"] = "abc123"
+    path = tmp_path / "consensus-state.json"
+    save_state(state, str(path))
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    checkpoint_dir = tmp_path / ".claude" / "debate-state" / "orchestrator"
+    checkpoint_dir.mkdir(parents=True)
+    checkpoint_path = checkpoint_dir / f"{path.name}.checkpoint.json"
+    checkpoint_path.write_text('{"step":"step4","round":2,"agent":"cc","response":{},"progress":{}}')
+
+    monkeypatch.setattr("debate_review.cli.state_file_path", lambda *args: str(path))
+    monkeypatch.setattr(
+        "debate_review.cli.gh_json",
+        lambda *args: {
+            "headRefName": "feat/test",
+            "headRefOid": "abc123",
+            "headRepositoryOwner": {"login": "owner"},
+        },
+    )
+
+    _run_cli(monkeypatch, [
+        "init", "--repo", "owner/repo", "--pr", "795",
+    ])
+    out = capsys.readouterr().out
+    result = json.loads(out)
+    assert "error" in result
+    assert "already completed" in result["error"]
+
+
 def test_cli_init_new_head_archives_old_state_and_clears_stale_checkpoint(monkeypatch, capsys, tmp_path):
     state = create_initial_state(
         repo="owner/repo",

--- a/skills/cc-codex-debate-review/tests/test_orchestrator.py
+++ b/skills/cc-codex-debate-review/tests/test_orchestrator.py
@@ -1070,6 +1070,7 @@ def test_terminal_still_runs_follow_through_when_post_comment_fails(monkeypatch,
 
     assert cli.mark_failed_calls == []
     assert cli.state["status"] == "consensus_reached"
+    assert not checkpoint_path.exists(), "checkpoint must be cleared even when post_comment fails"
 
 
 def test_mark_failed_still_runs_follow_through_when_post_comment_fails(monkeypatch, tmp_path):


### PR DESCRIPTION
## 문제현상

1. `consensus_reached` 등 정상 종료 세션에서 stale checkpoint가 남으면 `init` 재호출 시 완료된 세션이 `in_progress`로 되돌아감
2. `_terminal()`에서 `post_comment` 실패 시 `_clear_checkpoint()`에 도달하지 못해 stale checkpoint 잔류

## 구현내용

1. `cli.py`: checkpoint 복구 조건에 `status == "failed"` 확인 추가 — 정상 종료 세션은 checkpoint가 있어도 복구 차단
2. `orchestrator.py`: `_clear_checkpoint()`를 `comment_error` raise 전에 실행 — comment 실패와 무관하게 checkpoint 항상 정리
3. 두 버그에 대한 회귀 테스트 추가 (353 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)