### PR TITLE
fix(debate-review): application 실패한 이슈가 record-verdict를 차단하는 문제 해결

### DIFF
--- a/skills/cc-codex-debate-review/SKILL.md
+++ b/skills/cc-codex-debate-review/SKILL.md
@@ -363,6 +363,8 @@ The orchestrator **must** compare the new message against the existing reports a
 - `--verdict "no_findings_mergeable"`
 - Skip Steps 2, 3 and proceed to Step 4
 
+**Failed application handling:** If accepted issues have `application_status=failed`, the verdict is allowed but returns `needs_reapplication` with the list of issue IDs. The orchestrator must retry `apply-issue` for these before proceeding to Step 4.
+
 #### Report to User
 
 After routing all Step 1 results, **immediately report the debate content to the user**. Do not silently proceed to the next step. The user must see the debate as it happens:

--- a/skills/cc-codex-debate-review/SKILL.md
+++ b/skills/cc-codex-debate-review/SKILL.md
@@ -361,9 +361,9 @@ The orchestrator **must** compare the new message against the existing reports a
 
 **Clean pass determination:** If findings are 0 and all existing issues are resolved:
 - `--verdict "no_findings_mergeable"`
-- Skip Steps 2, 3 and proceed to Step 4
+- Continue to Step 2 for cross-verifier confirmation; Step 4 is only reachable if Step 2 is also clean
 
-**Failed application handling:** If accepted issues have `application_status=failed`, the verdict is allowed but returns `needs_reapplication` with the list of issue IDs. The orchestrator must retry `apply-issue` for these before proceeding to Step 4.
+**Failed application handling:** If accepted issues have `application_status=failed`, the verdict is allowed and returns `needs_reapplication` with the list of issue IDs. The round still proceeds through Step 2 and, if needed, Step 3; failed accepted issues remain in `{APPLICABLE_ISSUES}` so the lead can retry them during code application before settlement.
 
 #### Report to User
 

--- a/skills/cc-codex-debate-review/lib/debate_review/round_ops.py
+++ b/skills/cc-codex-debate-review/lib/debate_review/round_ops.py
@@ -71,7 +71,7 @@ def record_verdict(state, *, round_num, verdict) -> dict:
     if verdict == "has_findings":
         has_new_findings = bool(round_.get("step1", {}).get("report_ids"))
         open_issues = [i for i in state["issues"].values() if i["consensus_status"] == "open"]
-        excluded_statuses = {"applied"}
+        excluded_statuses = {"applied", "failed"}
         accepted_unresolved = [
             i for i in state["issues"].values()
             if i["consensus_status"] == "accepted"
@@ -88,6 +88,7 @@ def record_verdict(state, *, round_num, verdict) -> dict:
     round_["step1"]["verdict"] = verdict
 
     clean_pass = False
+    needs_reapplication = []
     if verdict == "no_findings_mergeable":
         issues = state["issues"]
 
@@ -102,15 +103,24 @@ def record_verdict(state, *, round_num, verdict) -> dict:
             i for i in accepted_issues if i["application_status"] != "applied"
         ]
         if not_applied:
-            raise ValueError(
-                f"verdict=no_findings_mergeable but {len(not_applied)} accepted issue(s) "
-                f"not yet applied"
-            )
-
-        clean_pass = True
+            # Separate truly pending from failed applications
+            failed = [i for i in not_applied if i["application_status"] == "failed"]
+            pending = [i for i in not_applied if i["application_status"] != "failed"]
+            if pending:
+                raise ValueError(
+                    f"verdict=no_findings_mergeable but {len(pending)} accepted issue(s) "
+                    f"not yet applied (status: pending)"
+                )
+            # Failed applications: allow verdict but flag for reapplication
+            needs_reapplication = [i["issue_id"] for i in failed]
+        else:
+            clean_pass = True
 
     round_["clean_pass"] = clean_pass
-    return {"round": round_num, "verdict": verdict, "clean_pass": clean_pass}
+    result = {"round": round_num, "verdict": verdict, "clean_pass": clean_pass}
+    if needs_reapplication:
+        result["needs_reapplication"] = needs_reapplication
+    return result
 
 
 def _collect_touched_issue_ids(round_):

--- a/skills/cc-codex-debate-review/tests/test_round_ops.py
+++ b/skills/cc-codex-debate-review/tests/test_round_ops.py
@@ -31,6 +31,81 @@ def test_record_verdict_clean_pass(sample_state):
     assert result["clean_pass"] is True
 
 
+def test_record_verdict_failed_accepted_issue_returns_needs_reapplication(sample_state):
+    init_round(sample_state, round_num=1, lead_agent="codex", synced_head_sha="abc")
+    sample_state["issues"]["isu_001"] = {
+        "issue_id": "isu_001",
+        "issue_key": "k1",
+        "opened_by": "codex",
+        "introduced_in_round": 1,
+        "criterion": 14,
+        "file": "src/a.py",
+        "line": 10,
+        "anchor": "foo",
+        "severity": "warning",
+        "consensus_status": "accepted",
+        "application_status": "failed",
+        "accepted_by": ["codex", "cc"],
+        "rejected_by": [],
+        "applied_by": "codex",
+        "application_commit_sha": None,
+        "consensus_reason": None,
+        "reports": [{
+            "report_id": "rpt_001",
+            "agent": "codex",
+            "round": 1,
+            "severity": "warning",
+            "message": "test",
+            "reported_at": "2026-03-30T00:00:00+00:00",
+            "status": "accepted",
+        }],
+        "created_at": "2026-03-30T00:00:00+00:00",
+        "updated_at": "2026-03-30T00:00:00+00:00",
+    }
+
+    result = record_verdict(sample_state, round_num=1, verdict="no_findings_mergeable")
+
+    assert result["verdict"] == "no_findings_mergeable"
+    assert result["clean_pass"] is False
+    assert result["needs_reapplication"] == ["isu_001"]
+
+
+def test_record_verdict_pending_accepted_issue_still_raises(sample_state):
+    init_round(sample_state, round_num=1, lead_agent="codex", synced_head_sha="abc")
+    sample_state["issues"]["isu_001"] = {
+        "issue_id": "isu_001",
+        "issue_key": "k1",
+        "opened_by": "codex",
+        "introduced_in_round": 1,
+        "criterion": 14,
+        "file": "src/a.py",
+        "line": 10,
+        "anchor": "foo",
+        "severity": "warning",
+        "consensus_status": "accepted",
+        "application_status": "pending",
+        "accepted_by": ["codex", "cc"],
+        "rejected_by": [],
+        "applied_by": None,
+        "application_commit_sha": None,
+        "consensus_reason": None,
+        "reports": [{
+            "report_id": "rpt_001",
+            "agent": "codex",
+            "round": 1,
+            "severity": "warning",
+            "message": "test",
+            "reported_at": "2026-03-30T00:00:00+00:00",
+            "status": "accepted",
+        }],
+        "created_at": "2026-03-30T00:00:00+00:00",
+        "updated_at": "2026-03-30T00:00:00+00:00",
+    }
+
+    with pytest.raises(ValueError, match="status: pending"):
+        record_verdict(sample_state, round_num=1, verdict="no_findings_mergeable")
+
+
 def test_settle_continue(sample_state):
     init_round(sample_state, round_num=1, lead_agent="codex", synced_head_sha="abc")
     record_verdict(sample_state, round_num=1, verdict="has_findings")


### PR DESCRIPTION
## Summary
- `record_verdict`에서 `application_status=failed`인 accepted 이슈가 `no_findings_mergeable` verdict를 차단하여 deadlock이 발생하는 문제 해결
- failed 상태의 이슈는 verdict를 허용하되 `needs_reapplication` 필드로 반환하여 orchestrator가 재적용할 수 있도록 변경
- auto-correction 로직에서도 `failed` 상태를 resolved로 취급하도록 수정

## Problem
Round 1에서 accepted된 이슈의 코드 적용이 실패(`application_status=failed`)한 경우, Round 2에서 lead agent가 새로운 이슈 없이 `no_findings_mergeable`을 판정하면 CLI가 "accepted issue(s) not yet applied" 에러를 발생시켜 deadlock 상태에 빠집니다.

## Fix
1. **auto-correction 로직**: `excluded_statuses`에 `"failed"` 추가하여 failed 이슈가 auto-correction을 차단하지 않도록 변경
2. **validation 로직**: not-applied 이슈를 `failed`와 `pending`으로 분리하여, pending만 ValueError를 발생시키고, failed는 `needs_reapplication` 필드로 반환
3. **SKILL.md**: `needs_reapplication` 필드 동작 문서화

Closes #238

## Test plan
- [ ] application_status=failed인 이슈가 있을 때 no_findings_mergeable verdict가 정상 반환되는지 확인
- [ ] 반환 결과에 needs_reapplication 필드가 포함되는지 확인
- [ ] application_status=pending인 이슈는 여전히 ValueError를 발생시키는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)