### PR TITLE
docs: clarify skills-jk PR workflow verification

### DIFF
--- a/.hermes/skills/software-development/skills-jk-gha-pr-creation/SKILL.md
+++ b/.hermes/skills/software-development/skills-jk-gha-pr-creation/SKILL.md
@@ -65,11 +65,13 @@ Instead:
 
 ## Pitfalls
 
-- Use plain `gh ...` commands in this repo; do not reintroduce a custom token-unset wrapper unless there is a repository-specific reason
+- Use plain `gh ...` commands in this repo; do not add a token-unset wrapper unless there is a specific repository need
 - Do not pass complex markdown directly to `gh pr create --body` in this repo unless there is a strong reason
 - `create-pr.yml` targets `main` as the base branch
 - The workflow appends a GitHub Actions bot footer to the body
 - If the branch has an existing open PR, the workflow may fail or create duplicate intent; check first
+- After dispatching the PR-creation workflow, verify completion with `gh run watch` and then confirm the resulting PR with `gh pr view` or `gh pr status`
+- `gh pr checks` may legitimately report no checks for the new PR branch; if so, also inspect `gh run list --branch <branch>` before concluding that no CI ran
 
 ## Evidence from use
 


### PR DESCRIPTION
## Summary
- refine the `skills-jk-gha-pr-creation` skill with practical post-dispatch verification guidance
- clarify that workflow completion should be checked explicitly after dispatch
- document the case where `gh pr checks` may show no checks and `gh run list --branch` should be checked instead

## Why
Most of the restored stash changes were stale or regressive against current `main`.
This file was the one worthwhile salvage item: it adds useful operational guidance without rolling back newer content.

## Test Plan
- documentation-only change
