### PR TITLE
docs: skill follow-up guidance 보강

### DIFF
--- a/.hermes/skills/github/github-pr-workflow/SKILL.md
+++ b/.hermes/skills/github/github-pr-workflow/SKILL.md
@@ -94,6 +94,19 @@ git rev-parse origin/main
 
 If they do not match, stop and inspect the branch ancestry before proceeding.
 
+Important interpretation rule for later review/debugging:
+- distinguish `local main was updated` from `the current root checkout was switched back to main`
+- a repository can have an up-to-date `main` ref while the root workspace is still checked out to some feature branch
+- when validating whether a PR branch was correctly based/rebased onto latest main, compare the PR head against the base tip that existed at PR creation/update time, not against a newer `origin/main` that may already include that PR merge
+- especially for merged PRs, `current origin/main` can be ahead by exactly the merge commit that absorbed the PR; that does **not** mean the PR branch failed to rebase onto latest main before merge
+- practical checks:
+  ```bash
+  gh pr view <number> --json headRefName,headRefOid,baseRefName,mergeCommit
+  git merge-base <pre-merge-base-tip> <pr-head-sha>
+  git rev-list --left-right --count <pre-merge-base-tip>...<pr-head-sha>
+  ```
+- use this wording discipline in reports too: say `root checkout was not restored to main yet` rather than incorrectly saying `main was not updated`
+
 Branch naming conventions:
 - `feat/description` — new features
 - `fix/description` — bug fixes

--- a/.hermes/skills/software-development/corp-web-japan-live-page-render-parity/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-japan-live-page-render-parity/SKILL.md
@@ -19,6 +19,7 @@ Use this when the user says a local/preview corp-web-japan page should *look the
 For page-parity work, code inspection alone is not enough.
 
 Reference notes:
+- `references/source-backed-widget-parity.md` — source-backed widget parity workflow: screenshot diff as hotspot detection, DOM/computed-style proof, and upstream component/CSS contract checks before accepting Tailwind rebuilds.
 - `references/about-us-parity-pitfalls.md` — concrete `/about-us` pitfalls for CTA-width interpretation and mixed-width team-card measurement.
 - `references/pr-preview-stage-render-audit-pattern.md` — reusable pattern for auditing a PR Preview Deployment against `stage.querypie.ai` across affected routes using Playwright geometry, screenshot pixel diffs, and wrapper padding/gutter root-cause analysis.
 - `references/certifications-mobile-gutter-audit.md` — concrete `/certifications` narrow-mobile gutter/card-width audit showing how `px-[30px]` behaves at 300/320/360/390px and when to prefer a card-gallery gutter preset.
@@ -36,10 +37,12 @@ Important findings from real usage:
 - Vision summaries can misread sparse/long pages and sometimes describe empty areas incorrectly.
 - The most reliable method is to combine:
   1. actual browser navigation to both URLs,
-  2. screenshots,
+  2. screenshots / pixel-diff artifacts as hotspot detection,
   3. DOM geometry from `getBoundingClientRect()`,
-  4. measured image sizes/positions,
-  5. local preview verification on the exact branch/worktree.
+  4. computed styles from `getComputedStyle()`,
+  5. measured image sizes/positions,
+  6. source/component/CSS contract inspection when the reference implementation exists in `../corp-web-app`,
+  7. local preview verification on the exact branch/worktree.
 - For PR follow-up visual fixes, the exact Vercel preview deployment URL can be a more trustworthy final reference than local dev, because the preview may render spacing rhythm differently enough for users to notice.
 - In particular, heading-spacing parity can fail if you optimize only against local dev measurements; always re-open the exact preview URL the user is looking at before concluding the spacing is fixed.
 - `next start` / local preview can serve stale output if you forget to rebuild or restart after changes.
@@ -78,12 +81,14 @@ Capture:
 - screenshots
 - DOM geometry for key sections
 
-### 2. Use screenshots, but do not trust vision alone
-Use `browser_vision()` to get a quick section-order/layout summary, but treat it as provisional.
+### 2. Use screenshots, but do not trust vision or screenshot diff alone
+Use `browser_vision()` and screenshot/pixel diff artifacts to get a quick section-order/layout/hotspot summary, but treat them as provisional.
 
 Important lesson:
+- Screenshot diff is effective for detecting visible drift, but it is not proof of root cause by itself.
 - On long pages with lots of whitespace, vision can misread the page as "mostly empty" even when the DOM contains the intended sections.
-- When vision and DOM disagree, trust the DOM + browser console measurements.
+- When vision/screenshot and DOM disagree, trust the DOM + browser console measurements.
+- For source-backed widget pages, after a screenshot hotspot is found, continue to DOM geometry, computed styles, and upstream component/CSS contract inspection before deciding the fix.
 
 ### 3. Measure real geometry in the browser console
 For parity work, always extract measured positions/sizes for the exact body elements you care about.
@@ -222,6 +227,8 @@ A page can have all the same headings and paragraphs yet still differ due to:
 - source-backed widget/application-contract pages being manually reimplemented with local Tailwind primitives instead of preserving the upstream component/CSS contract
 
 When upstream source exists for a widget page, inspect and preserve the source component chain first. Do not treat the source as merely a visual reference to approximate with new primitives unless a direct-port strategy has been explicitly rejected.
+
+For source-backed widget pages, text snapshots and route-local authorship also do not prove the upstream widget contract was preserved. If the reference implementation exists in `../corp-web-app`, inspect the upstream component chain and CSS modules before accepting a local Tailwind approximation. See `references/source-backed-widget-parity.md`.
 
 Important concrete lesson from `/t/solutions/aip/usage-based-llm` preview migration:
 - a migrated page can look superficially correct in snapshots because all headings, paragraphs, and images are present in the right order

--- a/.hermes/skills/software-development/corp-web-japan-live-page-render-parity/references/source-backed-widget-parity.md
+++ b/.hermes/skills/software-development/corp-web-japan-live-page-render-parity/references/source-backed-widget-parity.md
@@ -1,0 +1,94 @@
+# Source-backed widget render parity
+
+Use this reference when a corp-web-japan preview/stage page is expected to match a QueryPie reference page whose implementation exists in `../corp-web-app` as concrete widget/application components.
+
+## Key lesson
+
+Screenshot comparison is useful, but it is only a hotspot detector. It can reveal that a migrated page looks different, but it does not reliably explain whether the cause is root font-size policy, header/banner offset, lazy media timing, font loading, animation state, or a broken upstream component contract.
+
+For source-backed widget pages, use this evidence chain:
+
+1. Full-page and section-level screenshots / pixel diff identify visible hotspots.
+2. DOM geometry quantifies the specific element or section delta.
+3. Computed styles identify the property-level difference.
+4. Upstream source inspection identifies which component/CSS contract should be ported or intentionally rebuilt.
+
+A report that only says “screenshots differ” without element measurements and a source target is incomplete.
+
+## Source-backed widget classification
+
+Treat a page as source-backed widget/application work when:
+
+- the reference implementation exists in `../corp-web-app`, and
+- the page body is built from reusable application/widget components rather than simple static marketing sections, and
+- visual details are owned by concrete CSS modules or design-system primitives.
+
+Examples include pricing, plans, compare tables, tabbed product widgets, application-like feature browsers, and other components where button/icon/table/card chrome matters.
+
+## Required source-contract inventory
+
+Before coding or judging parity, record:
+
+- upstream route file
+- upstream widget/component files
+- upstream CSS module files
+- local route file
+- local section/component files
+- whether local code directly ports the upstream contract or rebuilds it
+- compatibility layers for upstream buttons, icons, tabs, cards, tables, and tokens
+- whether remaining deltas are intentional local policy or missing contract porting
+
+## Strategy decision
+
+Choose and document one strategy before declaring the page acceptable:
+
+### Direct-port strategy
+
+Port the upstream component structure and CSS-module visual contract as closely as possible. Add small compatibility layers for local tokens, buttons, icons, layout wrappers, or asset paths when needed.
+
+Use this when the upstream source already expresses the intended UI contract and the page is widget-like.
+
+### Measured-rebuild strategy
+
+Keep local primitives, but require evidence that the rebuilt UI is visually equivalent enough:
+
+- screenshot / pixel diff artifacts
+- DOM geometry anchors
+- computed-style comparisons
+- explicit root-rem / final-pixel decision
+- source-contract checklist showing what was intentionally not ported
+
+Use this only when direct porting is not practical or would conflict with an approved local site policy.
+
+## `/t/plans` lesson
+
+`/t/plans` is not just a static marketing page. The reference plans page is backed by pricing and compare-table widgets in `../corp-web-app`.
+
+For this page, text presence and route-local authoring are not sufficient. A parity audit must check at least:
+
+- product tab geometry/style
+- plan card outer geometry and internal typography
+- button component and icon wrapper behavior, not text glyph approximations
+- feature-list icon/text rhythm
+- comparison-table wrapper width/overflow
+- table section rows, normal rows, cell padding, and row heights
+- root font-size and final-visible-pixel vs token-intent decision
+
+If local code replaces the upstream pricing/compare-table contract with generic local Tailwind cards/tables/buttons without a documented measured-rebuild decision, classify that as a likely root cause of visual drift.
+
+## Reporting rule
+
+Classify findings as one of:
+
+- actual defect
+- intentional local-site adaptation
+- external live-site artifact
+- environment artifact
+- needs decision
+
+For every actual defect, include:
+
+- screenshot or diff hotspot
+- DOM geometry or computed-style evidence
+- likely source/component/CSS contract to inspect next
+- whether the fix should direct-port or measured-rebuild the upstream contract

--- a/.hermes/skills/software-development/corp-web-japan-marketing-page-authoring/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-japan-marketing-page-authoring/SKILL.md
@@ -189,6 +189,25 @@ Recommended assertions after the move:
 
 Do not leave old tests asserting that page-level intro strings still live inside the form/component file after the authoring split.
 
+## Follow-up PRs for already-merged static preview pages
+
+When the user asks to perform route-local refactoring “for” an already-merged PR:
+- first check the referenced PR state with `gh pr view <number>`
+- if it is merged, do not revive or push to the old PR branch
+- start a fresh worktree from the latest `origin/main`, inspect the merged PR's file list, and create a new refactor PR scoped to the merged surfaces
+- use the merged PR only as the source inventory for target routes/assets/tests
+
+For static preview routes that were initially added with data-driven section renderers, a good follow-up route-local refactor is:
+- move visible copy, section headings, card titles/descriptions, CTA labels, and image composition into each route `page.tsx` as direct JSX
+- convert the shared section file from prop/data renderers into UI-only primitives such as `*Section`, `*Heading`, `*LeadGroup`, `*Card`, `*CardTitle`, `*CardDescription`, `*Grid`, `*Image`, and CTA primitives
+- keep route-level arrays only when they are the clearer authoring surface for large homogeneous catalogs; controller/static marketing pages should usually avoid top-level blobs like `const heroDescription`, `const keyFeatures`, and `const capabilityImages`
+- update narrow source tests to assert both sides of the contract: route files no longer define the removed data blobs and shared section modules no longer contain hardcoded marketing copy or `.map()`-based data renderers
+
+Practical pattern from ACP static preview route follow-up:
+- PR #506 added ACP static preview pages under `/t/platforms/acp/**` with page-local data arrays and shared `src/components/sections/acp/static-page.tsx` renderers
+- the route-local follow-up rebuilt the four controller pages so copy/cards/gallery/CTA are authored directly in `page.tsx`, while `static-page.tsx` exports UI primitives only
+- the integrations route already had a large homogeneous catalog and route-owned hero/category/product data, so the follow-up only aligned its shared CTA usage instead of forcing every catalog item into JSX
+
 ### Important source-reader pitfall
 
 In corp-web-japan, some test helpers prefer externalized sources first, for example:

--- a/.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md
@@ -439,6 +439,21 @@ Execution rules:
 
 This is different from a normal refactor PR: the purpose is to make a reviewable preview state for human visual judgment, so do not squash it immediately into the original commit unless the user later chooses that result as final.
 
+## Small preview-route copy edit pattern
+
+When the user requests a narrow copy change on an existing corp-web-japan `/t/**` preview route, keep the implementation deliberately small rather than reopening the whole page-parity workflow.
+
+Recommended pattern:
+1. Start from latest `origin/main` in a fresh non-main worktree as usual.
+2. Edit the visible route copy in `src/app/**/page.tsx` and update matching page metadata (`metadata.title` / `metadata.description`) when the changed hero title or lead is also the browser/SEO preview text.
+3. Preserve the user's exact Japanese copy when they provide it; do not paraphrase or expand it into new marketing claims.
+4. Add or update the mirrored source-level route test so it asserts the new copy is present and any explicitly replaced old wording is absent.
+5. For copy-only changes, use the narrow source test first and rely on CI/Preview Deploy after push; do not start a local dev server or broaden into visual/browser parity unless the user asked for visual validation.
+
+Example shape from `/t/platforms/acp` hero-copy work:
+- update `src/app/t/platforms/acp/page.tsx` hero title/lead and metadata together
+- update `tests/src/app/t/platforms/acp/page.test.mjs` with positive assertions for the new title/description and negative assertions for the removed old title/extra explanatory sentence
+
 ## Pre-push rule
 
 Before pushing or updating a PR branch:

--- a/.hermes/skills/software-development/safe-git-worktree-branch-cleanup/SKILL.md
+++ b/.hermes/skills/software-development/safe-git-worktree-branch-cleanup/SKILL.md
@@ -336,6 +336,25 @@ Practical rule:
 - if those are the only remaining changes, treat the repo/worktree as effectively clean for stale-classification purposes, or delete just those local residue paths when the user asked for cleanup
 - if the remaining dirt is real project files (for example tracked deletions like `D postcss.config.mjs`), preserve the worktree
 
+Important provenance check before deleting untracked files:
+- do not treat every untracked file as disposable just because it appeared during the current session
+- especially under checked-in skill/doc trees such as `.hermes/skills/**`, `.agents/skills/**`, `docs/**`, or `references/**`, an untracked file may be meaningful local authored content rather than runtime junk
+- before deleting an untracked file, classify it with evidence:
+  - obvious lock/cache/usage artifact (for example `.lock`, machine-local usage DB, cache file)
+  - clearly generated diagnostics/build output
+  - or potentially user-authored content
+- safe rule:
+  - `rm` obvious runtime artifacts like lockfiles/caches only when their generated nature is clear
+  - do **not** delete prose/reference markdown or other content-like untracked files inside skill/doc trees without confirming provenance first or asking the user
+- if a tool interaction such as skill lookup/view seems to have created or modified repo-local files, prefer restoring tracked files only and report the remaining untracked files explicitly instead of silently deleting them all
+- useful checks:
+  ```bash
+  git ls-files --error-unmatch <path> >/dev/null 2>&1 && echo tracked || echo untracked
+  file <path>
+  ls -l <path>
+  ```
+- reporting rule: when cleanup restored tracked files but left untracked content-like files alone, say that directly instead of implying all dirt was safely disposable
+
 Important generated-artifact pitfall:
 - do not delete a path just because its name looks disposable, such as `log/`, `logs/`, `manifest.json`, `*.pub`, or similar build/output-looking names
 - first verify whether the path is actually untracked local residue versus tracked repository content:
@@ -667,6 +686,12 @@ A common pattern is:
 - the branch `HEAD` is exactly equal to local `main` / `origin/main`
 - the attached worktree is clean
 - the branch name suggests a one-off helper or topic, but the tree no longer differs from main at all
+
+Important counter-case:
+- the branch `HEAD` can still equal `main` / `origin/main`, yet the attached worktree may contain meaningful tracked modifications
+- in that case, the branch pointer itself is a no-op alias, but the live worktree is **not** stale residue
+- do not delete that worktree just because the branch SHA matches main; classify the current dirty patch separately
+- if you want cleaner naming, you may rename the branch into an explicit preservation namespace such as `preserve/*` or another user-meaningful local branch name before reporting the final state
 
 Check this with:
 

--- a/.hermes/skills/software-development/skills-jk-gha-pr-creation/SKILL.md
+++ b/.hermes/skills/software-development/skills-jk-gha-pr-creation/SKILL.md
@@ -58,6 +58,10 @@ Trigger this skill when:
    - If you need a branch-specific lookup, use `gh pr list --head <branch>` or `gh pr view <branch>`.
    - Do not use `gh pr view --head <branch>`; that flag is not supported by `gh pr view` and fails with `unknown flag: --head`.
    - Do not rely on `gh run list --branch <branch>` to prove the PR-creation workflow ran; that branch filter may show nothing for this workflow even when PR creation succeeded.
+   - After the final push/update, verify the actual remote branch ref directly before trusting PR metadata:
+     - `git rev-parse HEAD`
+     - `git ls-remote origin refs/heads/<branch>`
+   - Treat the remote ref match as the source of truth for whether the branch tip really reached GitHub. `gh pr view` / `gh pr status` can lag briefly after push or workflow-driven PR creation.
    - Report the PR number and URL
 
 ## If a PR already exists


### PR DESCRIPTION
## 요약
- skill 문서 내 최근 실제 사용 패턴을 반영해 Git/PR 해석 규칙을 보강했습니다
- corp-web-japan parity/preview 관련 follow-up guidance를 보완했습니다
- untracked reference 문서를 추가해 source-backed widget parity 점검 기준을 명시했습니다

## 변경 파일
- `.hermes/skills/github/github-pr-workflow/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-live-page-render-parity/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-live-page-render-parity/references/source-backed-widget-parity.md`
- `.hermes/skills/software-development/corp-web-japan-marketing-page-authoring/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md`
- `.hermes/skills/software-development/safe-git-worktree-branch-cleanup/SKILL.md`
- `.hermes/skills/software-development/skills-jk-gha-pr-creation/SKILL.md`

## 메모
- root `main`은 최신 `origin/main`으로 fast-forward 업데이트했습니다.
- local generated usage/lock 파일은 PR 범위에서 제외했습니다.
