### PR TITLE
docs: update skill follow-ups for profile and publication audits

### DIFF
--- a/.hermes/skills/autonomous-ai-agents/hermes-agent/SKILL.md
+++ b/.hermes/skills/autonomous-ai-agents/hermes-agent/SKILL.md
@@ -199,6 +199,13 @@ hermes profile export NAME  Export to tar.gz
 hermes profile import FILE  Import from archive
 ```
 
+Important current-session limitation:
+- profiles are selected at process/session start (for example `hermes -p deep`) or changed as the sticky default for future launches with `hermes profile use <name>`
+- the currently running session does **not** support hot-swapping its active profile in place
+- `/profile` is for showing the active profile/info, not switching the current session to another profile
+- if the user wants the *current* session to behave more like another profile, the nearest in-session substitutes are `/model <name>` and `/reasoning <level>`
+- if the user wants the actual profile changed, start a new Hermes session with `-p/--profile` or change the sticky default for the next launch
+
 ### Credential Pools
 
 ```

--- a/.hermes/skills/github/codebase-inspection/SKILL.md
+++ b/.hermes/skills/github/codebase-inspection/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: codebase-inspection
-description: Inspect and analyze codebases using pygount for LOC counting, language breakdown, and code-vs-comment ratios. Use when asked to check lines of code, repo size, language composition, or codebase stats.
+description: Inspect and analyze codebases using lightweight file/content search and pygount for LOC counting, language breakdown, and code-vs-comment ratios. Use when asked to find repo documents/files, check lines of code, repo size, language composition, or codebase stats.
 version: 1.0.0
 author: Hermes Agent
 license: MIT
@@ -14,10 +14,11 @@ prerequisites:
 
 # Codebase Inspection with pygount
 
-Analyze repositories for lines of code, language breakdown, file counts, and code-vs-comment ratios using `pygount`.
+Analyze repositories for targeted documents/files, lines of code, language breakdown, file counts, and code-vs-comment ratios. Prefer the lightest inspection that answers the user’s actual question; use `pygount` only for repo metrics.
 
 ## When to Use
 
+- User asks to find a document or file in a repo, especially under a specific directory
 - User asks for LOC (lines of code) count
 - User wants a language breakdown of a repo
 - User asks about codebase size or composition
@@ -38,6 +39,34 @@ pip install --break-system-packages pygount 2>/dev/null || pip install pygount
 ```
 
 If the `pygount` shell command is missing but the Python package is installed, use the module entrypoint below instead. On some environments, `python3 -m pygount` does not work because the package has no `__main__`; `python3 -m pygount.command` is the reliable fallback.
+
+## 0. Lightweight Document/File Lookup
+
+When the user asks to “find the goal doc under docs” or similar, do not stop at filename matching. Use a two-pass lookup:
+
+1. Search filenames in the requested subtree for the literal clue and common variants.
+2. If filename search is empty or ambiguous, search Markdown headings and nearby content for the same clue.
+3. Report concise results with exact path and line numbers. If no filename matches, say that explicitly and distinguish it from content/heading matches.
+
+Example shape:
+
+```bash
+# filename clue
+find docs -iname '*goal*' -type f
+
+# heading/content clue
+rg -n --glob '*.md' '^(#+ .*\b[Gg]oals?\b)|\b[Gg]oals?\b' docs
+```
+
+For user-facing replies, prefer a short answer like:
+
+```text
+docs/plans/example.md
+- line 5: ## Goal
+- line 7: <one-line summary>
+
+파일명에 goal이 들어간 문서는 없습니다.
+```
 
 ## 1. Basic Summary (Most Common)
 
@@ -131,4 +160,4 @@ Special pseudo-languages:
 3. **JSON files show low code counts** — pygount may count JSON lines conservatively. For accurate JSON line counts, use `wc -l` directly.
 4. **Large monorepos** — for very large repos, consider using `--suffix` to target specific languages rather than scanning everything.
 5. **Stop quickly if the scan is slower than expected** — if a repo-wide scan on a docs/content-heavy repo does not return promptly, interrupt it and switch to a narrower inspection. Do not keep waiting on a long-running analysis when a lighter method would answer the user’s actual question.
-6. **Docs/content repos can be misleadingly expensive** — repositories with large `var/`, cached exports, generated snapshots, or content mirrors may look simple but still be expensive to scan. Narrow the target path or skip LOC analysis unless the user explicitly wants codebase metrics.
+7. **Do not equate filename misses with document misses** — when a user asks for a “goal doc” or similarly named document, a filename-only search may return nothing while the real target has a `## Goal` heading. Follow filename search with heading/content search before reporting no result.

--- a/.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md
@@ -198,6 +198,8 @@ For a fresh branch with no new commits yet, these should all match.
 6. Preserve latest merged content exactly unless the user asked to change it.
 - Titles and branding labels are especially easy to regress.
 - If a recent PR finalized labels/titles, keep them untouched while adding new metadata fields.
+- In live-parity or migration-goal follow-up work, do not automatically treat live/corp-web-contents wording as authoritative over latest-main product-copy decisions. If the user says a PR is reverting an intentional latest-main title, hero lead, or metadata description change, update the governing goal/plan/skill doc to mark that wording as an intentional parity exception rather than changing the route back.
+- For bilingual goal documents, mirror the exception in both language sections so future agents reading either half avoid the same revert.
 
 6. For metadata / SEO work, add a failing test first.
 - Prefer a small repository-level regression test that checks file contents or metadata patterns.

--- a/.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/SKILL.md
@@ -42,6 +42,27 @@ Order matters:
 
 ## Audit workflow
 
+### 0. Classify legacy in-body QueryPie resource links before changing them
+
+When the task is to replace `https://www.querypie.com/ja/**` links inside publication/article/whitepaper/blog MDX bodies:
+
+1. Search the touched MDX files for the exact legacy URLs first.
+2. Extract the legacy resource family, numeric id, slug, and optional hash fragment.
+3. Check the current local content corpus before deciding the replacement:
+   - whitepapers: `src/content/whitepapers/<id>-*.mdx` and frontmatter `slug`
+   - blog: `src/content/blog/<id>-*.mdx` and frontmatter `slug`
+   - news/events/demo/use-cases: corresponding `src/content/<family>/` roots
+4. If a local canonical record exists, replace the external URL with the local canonical path and preserve any hash fragment exactly.
+   - Example: `https://www.querypie.com/ja/resources/discover/white-paper/8/secure-login-token-management#脅威の種類` -> `/whitepapers/8/secure-login-token-management#脅威の種類`
+5. If no local canonical record exists, do **not** invent a local path. Classify the item first as one of:
+   - needs full local migration
+   - needs hidden shadow record with `redirectUrl`
+   - needs route-level legacy redirect only
+   - should remain external because there is no local replacement yet
+6. After editing, search the touched files for the old `www.querypie.com/ja` resource namespace and confirm zero residue for the requested URLs.
+
+Useful example details from a successful link-replacement pass are in `references/legacy-inbody-resource-link-replacement.md`.
+
 ### 1. Inspect record-loader support
 
 Read the relevant `src/lib/publications/*-publication-records.ts` file and confirm:

--- a/.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/references/legacy-inbody-resource-link-replacement.md
+++ b/.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/references/legacy-inbody-resource-link-replacement.md
@@ -1,0 +1,37 @@
+# Legacy in-body QueryPie resource link replacement
+
+Use this reference when a corp-web-japan task asks to replace `https://www.querypie.com/ja/**` links inside MDX article/blog/whitepaper bodies with local canonical resource routes.
+
+## Decision rule
+
+For each legacy URL:
+
+1. Search the exact URL in the touched MDX file(s).
+2. Extract resource type, id, slug, and hash fragment.
+3. Verify the local record exists in the current checkout, preferably by filename and frontmatter:
+   - whitepapers: `src/content/whitepapers/<id>-*.mdx`
+   - blogs: `src/content/blog/<id>-*.mdx`
+   - news/events/use-cases/demo: corresponding `src/content/<family>/` roots
+4. If the local record exists, replace with canonical local path and preserve the fragment.
+5. If the local record does not exist, stop before inventing a local URL and classify the missing resource as local migration vs hidden shadow record vs redirect-only vs remain external.
+
+## Session examples
+
+Legacy whitepaper URLs in blog bodies mapped cleanly to local canonical whitepaper routes:
+
+| Legacy URL | Local record | Replacement |
+|---|---|---|
+| `https://www.querypie.com/ja/resources/discover/white-paper/8/secure-login-token-management#脅威の種類` | `src/content/whitepapers/8-secure-login-token-management.mdx` | `/whitepapers/8/secure-login-token-management#脅威の種類` |
+| `https://www.querypie.com/ja/features/documentation/white-paper/29/ai-agent-guardrails-governance-2026-implementation` | `src/content/whitepapers/29-ai-agent-guardrails-governance-2026-implementation.mdx` | `/whitepapers/29/ai-agent-guardrails-governance-2026-implementation` |
+| `https://www.querypie.com/ja/resources/discover/white-paper/2-shell-native-command-control` | `src/content/whitepapers/2-shell-native-command-control-ssh-proxy-architecture.mdx` | `/whitepapers/2/shell-native-command-control-ssh-proxy-architecture` |
+| `https://www.querypie.com/ja/resources/discover/white-paper/5-preventing-command-bypass` | `src/content/whitepapers/5-preventing-command-bypass.mdx` | `/whitepapers/5/preventing-command-bypass` |
+
+## Verification pattern
+
+Run a static residue check against the touched files, e.g. search for:
+
+```text
+https://www\.querypie\.com/ja/(resources/discover/white-paper|features/documentation/white-paper)
+```
+
+For content-only MDX link rewrites, a focused source-level test is usually enough. In corp-web-japan, `npm run test -- <specific tests>` may be routed through `scripts/ci/run-node-tests.mjs` and execute broader grouped suites than the argument list suggests; treat a broad pass as acceptable but do not assume it was narrowly scoped.


### PR DESCRIPTION
## 요약
- Hermes profile/current-session limitation 관련 skill 설명을 보강했습니다
- codebase-inspection에 문서/heading 기반 경량 탐색 규칙을 추가했습니다
- corp-web-japan publication hidden/redirect audit 관련 legacy in-body link replacement 절차와 reference를 추가했습니다
- latest-main title/copy 의도 보존 관련 worktree safety 문서를 보강했습니다

## 포함 파일
- `.hermes/skills/autonomous-ai-agents/hermes-agent/SKILL.md`
- `.hermes/skills/github/codebase-inspection/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-origin-main-worktree-safety/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/SKILL.md`
- `.hermes/skills/software-development/corp-web-japan-publication-hidden-redirect-audit/references/legacy-inbody-resource-link-replacement.md`
