### PR TITLE
docs: update local Hermes memory follow-ups

### DIFF
--- a/.hermes/memories/MEMORY.md
+++ b/.hermes/memories/MEMORY.md
@@ -100,6 +100,8 @@ In corp-web-v2 Solutions static-page work, the user wants file/directory structu
 §
 In corp-web-v2 route-policy work, the user wants the webinars family to use top-level `/webinars` for the public list route as well, not `/demo/webinars`; align code and the Public-Content-URL-Naming-Convention wiki in the same batch.
 §
+User's Hermes CLI is git-installed under ~/.hermes/hermes-agent, with ~/.local/bin/hermes symlinked to ~/.hermes/hermes-agent/venv/bin/hermes, and current config lives in ~/workspace/skills-jk/.hermes/.
+§
 In corp-web-v2 Public-Content-URL-Naming-Convention updates, treat src/app/[locale]/features/demo/page.tsx and src/app/[locale]/features/documentation/page.tsx as legacy-only paths; do not count them as migration targets or implementation results.
 §
 In corp-web-v2 blog/white-paper MDX, the canonical upstream slug from corp-web-contents is now stored explicitly as frontmatter `slug` in each `src/content/mdx/blog/<id>/<locale>.mdx` and `src/content/mdx/white-papers/<id>/<locale>.mdx`, while the directory name remains the numeric content ID.
@@ -114,7 +116,11 @@ The corp-web-japan GitHub wiki repository is locally cloned at ../corp-web-japan
 §
 In corp-web-japan, the `/events` route currently exists as a functional page shell before content is ready; it is not part of the current public launch scope.
 §
+The active Hermes runtime uses HERMES_HOME=~/workspace/skills-jk/.hermes in this setup; treat that as the primary home for session state, logs, and agent-local artifacts unless evidence shows a different profile/home.
+§
 Hermes session files for this setup are stored under ~/workspace/skills-jk/.hermes/sessions, and direct file inspection there can reveal recent Telegram sessions beyond what session_search returns.
+§
+User asked to roll back git-installed Hermes from unstable main HEAD to a recent stable release; local Hermes repo was checked out at tag v2026.4.16 and the gateway was restarted.
 §
 For searching all historical file paths in a git repo and filtering by substring, the user uses the one-liner: git log --all --name-only --pretty=format: | sed '/^$/d' | sort -u | grep '<substring>'.
 §
@@ -138,7 +144,7 @@ In corp-web-japan, when a refactor workflow is likely to be repeated across sess
 §
 In corp-web-japan static-page route-local authoring, docs/code-location-conventions.md can be outdated; the user's desired target pattern is current src/app/page.tsx on latest main, src/app/solutions/ai-dashi/page.tsx is only partially refactored toward that goal, and src/app/solutions/ai-crew/page.tsx is the archetypal pre-refactor anti-pattern.
 §
-In corp-web-japan, route-local means `src/app/**/page.tsx` owns copy/order/composition while UI/styling components live under `src/components/sections/**` unless excepted. `InternalDemo*` is okay only for strictly internal-demo-local UI; reusable/component-candidate symbols need production-ready neutral names.
+In corp-web-japan static-page authoring, src/app/**/page.tsx should contain the copy text and the calls/composition that use components, while src/components/sections/** should define the components used by page.tsx and hold the style/UI/UX implementation details such as classes, JavaScript, and styling behavior.
 §
 In corp-web-japan main as of 2026-05-03, local `next build --webpack` fails on an existing baseline CSS Modules error in `src/components/layout/site-header.module.css`: `:root` selector is not pure. This is independent of the use-cases MDX migration branch.
 §
@@ -154,7 +160,7 @@ In corp-web-japan resource preview/publication work, the user explicitly does no
 §
 In corp-web-japan section-scoped static-page refactors, preserve the original rendered section order. If extracting a later section (e.g. use-cases) would move it ahead of an earlier section still trapped in a shared shell (e.g. platform), refactor the earlier section first or split the shared shell before extracting the later one.
 §
-In corp-web-japan CTA primitive refactors, the user prefers `SimpleCtaSection` over generic `CtaSection`, keeps child names like `CtaContent`/`CtaCopy`/`CtaTitle`/`CtaDescription`/`CtaActions`, and interprets `AipFreeTrialCtaSection` as “try AIP free” product intent, not “CTA used only on AIP pages.”
+In corp-web-japan CTA primitive refactors, the user prefers the section wrapper to be named `SimpleCtaSection` rather than the more generic `CtaSection`, while keeping child primitive names like `CtaContent`, `CtaCopy`, `CtaTitle`, `CtaDescription`, and `CtaActions` unchanged.
 §
 In corp-web-japan preview-site parity work, the user wants the preview website to keep a standard 16px root rem setup; when matching a live site that uses a 15px root, adjust component token sizes/spacing for visual parity rather than changing the preview site's root font-size.
 §
@@ -166,13 +172,15 @@ In corp-web-japan preview resource publication work, the user is concerned about
 §
 In corp-web-japan PR follow-up work, gh pr view can briefly lag after push; verify the actual remote branch tip with `git ls-remote origin refs/heads/<pr-branch>` before assuming the PR head failed to update.
 §
-In corp-web-japan typography/layout unification work, the user prefers site-wide consistency over route-local parity exceptions and does not want inconsistent padding/margin/spacing assumed to be intentional or appropriate. When the user names a baseline page for unification, apply that baseline literally across spacing, typography, and width without leaving page-specific exceptions.
+In corp-web-japan typography work, the user prefers site-wide consistency over route-local parity exceptions: do not keep `/t/about-us` as a special text-color or body-typography exception; align it to shared site defaults instead. Current documented defaults are route-level `main` `text-slate-950`, ordinary descriptive/body copy `text-slate-600`, and for marketing/company body copy the preferred default is `15px/28px` (`text-[15px] leading-7`) unless a different shared pattern is explicitly required.
 §
 In corp-web-japan demo list-route rollout work, canonical list paths should stay under the demo namespace: use-cases `/demo/use-cases`, AIP `/demo/aip`, ACP `/demo/acp`. Do not invent `/demo-acp` or lift use-cases to `/use-cases` unless the user explicitly changes the route policy.
 §
 In corp-web-japan, .github/workflows/ci.yml and deploy-preview.yml both support workflow_dispatch. If a PR branch push updates head SHA but GitHub does not attach new synchronize runs, manual dispatch on the PR branch can still validate the current head.
 §
 In corp-web-japan manuals work, the real replacement target for legacy /api-docs.html is https://docs.querypie.com/ja/api-reference.
+§
+On this machine, exiftool is installed and available in PATH.
 §
 In corp-web-japan, Vercel WAF custom rules are now managed as a repo-committed source of truth under ops/vercel-firewall/, with a project-specific JSON payload plus README, and applied project-scoped via full PUT to /v1/security/firewall/config for corp-web-japan.
 §
@@ -198,7 +206,7 @@ In corp-web-japan publication-helper planning, the user wants the current low-le
 §
 In corp-web-japan legal preview work, route-local self-contained placement under src/app/t/<route>/ can be preferable to broad src/content/legal-preview + src/lib/legal-preview indirection; for versioned privacy-policy previews, the user expects `src/app/t/privacy-policy/[slug]/page.tsx` to own page composition while `src/app/t/privacy-policy/page.tsx` may remain a thin latest-version wrapper that derives the last document date.
 §
-In corp-web-japan legal MDX work: standalone legal pages like terms-of-service prefer route-local MDX colocation (page.tsx + content.mdx). Effective dates should come from ../corp-web-contents source/history; if no explicit source date exists, use the source file's first-add git date.
+In corp-web-japan, for standalone static/legal preview pages like terms-of-service, the user prefers route-local MDX colocation: keep page.tsx and content.mdx in the same route directory (e.g. src/app/t/terms-of-service/) rather than placing the MDX under src/content.
 §
 In the repo-local Hermes setup at ~/workspace/skills-jk/.hermes/config.yaml, mcp_servers.chrome-devtools is configured with npx chrome-devtools-mcp@latest and Hermes reports it enabled via `hermes mcp list`.
 §
@@ -208,7 +216,7 @@ In corp-web-japan publication UX, the user expects introduction-deck gated downl
 §
 In corp-web-japan mobile resource/demo sidebar UX, after comparing alternatives the user chose the bottom-sheet/drawer navigation pattern over the block-list/grid pattern as the preferred final direction.
 §
-In corp-web-japan preview-page parity work, when the user asks to fix multiple remaining pages together (e.g. issue 454 /t/services or /t/platforms pages), they expect each page handled in its own fresh worktree, branch, and separate PR.
+In corp-web-japan service preview parity work, when the user asks to fix multiple `/t/services/*` pages together (such as ACP and FDE), they want each page handled in its own fresh worktree and its own separate PR, not bundled into one combined PR.
 §
 The user wants the repeated repo-local stale-branch/worktree audit workflow encoded as a reusable skills-jk skill: classify non-open-PR branches by synthetic squash of current local state vs latest origin/main, test disposable rebase onto latest main, preserve meaningful local patches, and delete only clearly stale branches/worktrees.
 §
@@ -218,7 +226,7 @@ In the repo-local Hermes config at ~/workspace/skills-jk/.hermes/config.yaml, ch
 §
 In corp-web-japan, the user wants remaining legacy `/posts/` route/code/content remnants removed entirely rather than preserved for event compatibility.
 §
-In corp-web-japan taxonomy: AIP/ACP use preview `/t/platforms/{aip,acp}` and final `/platforms/{aip,acp}`; AIP child pages use `/platforms/aip/{slug}` except no FDE child; FDE stays `/t/services/fde` -> `/services/fde`. Use `Aip*`, not `AipService*`, for AIP page/section primitives. `/t/*` removal is final-release only.
+In corp-web-japan path taxonomy work, the user wants the temporary `t-` prefix kept only in app route paths; do not use `t-` in component or test family names. Use neutral family names like `aip`, `acp`, and `fde` instead of `t-services-aip`, `t-services-acp`, or `t-services-fde`.
 §
 In corp-web-japan path taxonomy naming, the user wants a single canonical family name chosen on general convention rather than current code habit; use `home` instead of `top-page` for the homepage component/test family.
 §
@@ -229,9 +237,3 @@ In corp-web-japan, default text content width is 1200px unless a side-by-side im
 In corp-web-japan test structure work, the user wants only genuinely reusable infra helpers kept in shared test helper locations; page-specific or page-family-specific helpers should be colocated near the relevant mirrored test paths instead of centralized under tests/helpers.
 §
 corp-web-japan main requires `Detect changed scope`, but ci.yml pull_request ignores docs/README/AGENTS/public md/skills md changes, so docs-only PRs can miss the required check.
-§
-In this environment, read_file output includes display-only line-number prefixes like `1|`; do not treat that formatted output as raw file contents when rewriting files, or repeated saves can duplicate those prefixes into documents.
-§
-corp-web-japan AIP integrations filters use semantic keyword keys (e.g. `workflow-automation`), not numeric IDs; for issue 454, do not keep live numeric query/filter parity as remaining scope—PR #490 was closed as wrong-scope.
-§
-In corp-web-japan AIP parity, live hero YouTube is square/no-shadow and poster-first using `public/aip/aip-video-thumb-jp.png`; immediate iframe or rounded/shadowed video chrome is a defect.

--- a/.hermes/memories/USER.md
+++ b/.hermes/memories/USER.md
@@ -12,7 +12,7 @@ User wants PR status checked before commit/push on repo work to avoid continuing
 §
 For repo work, the user wants brief progress updates, immediate execution once the requested change is clear, and no long passive waits. Give a short status/estimate first, avoid proposal-only pauses, and if commands run long or estimates are exceeded, stop and report status promptly instead of waiting silently.
 §
-User prioritizes rendered website consistency over nominal component reuse, expects critical re-evaluation of visual claims, and wants shared design-policy issues distinguished from page-specific defects.
+User prioritizes actual website appearance over technical implementation details when evaluating stakeholder-facing UI changes.
 §
 User says there is no policy that the Japanese site's default font must be Pretendard JP; do not treat that as a constraint.
 §
@@ -46,7 +46,7 @@ In corp-web-v2 asset migration work, the user prefers non-image assets like anim
 §
 User does not want local or CI reruns to be left waiting for long periods; avoid long passive waits when checking verification after repo changes.
 §
-For repo work, the user expects changes to be committed, pushed, reflected in the PR without being asked again; existing PR body rewrites should be grounded in the current diff/files/check status and remove stale claims.
+For repo work, the user expects changes to be committed, pushed, and reflected in the PR without being asked again.
 §
 In corp-web-v2, the user wants repeated local npm install in fresh worktrees avoided when possible because it causes significant delay.
 §
@@ -104,7 +104,7 @@ User does not need local build testing or local dev servers for corp-web-japan c
 §
 When asking to rewrite repository wiki documentation, the user wants it based on the latest main branch implementation rather than an in-progress feature branch.
 §
-For corp-web-japan issue/link-audit docs, user prefers markdown [path](url) links, Korean translation columns for Japanese labels, and Korean translations after Japanese text. For Japanese web copy, user values comparing wording alternatives and tone differences before final selection.
+When documenting corp-web-japan issues or link audit tables, the user prefers all links written in markdown [path](url) format, wants a Korean translation column next to Japanese labels, and when showing Japanese text to the user expects a Korean translation in parentheses immediately after it.
 §
 PRs should only be closed after explicit user approval. Unless the user explicitly instructs 'close the PR', do not close it.
 §
@@ -122,7 +122,7 @@ For corp-web-v2 documentation sidebar requests, preserve the exact ordered struc
 §
 The user requires repo work to start from latest main by default, expects local `main` to be explicitly fast-forward updated when review is said to be based on current main, and wants PR branches rebased onto latest main before push/PR update.
 §
-TABOO: never edit `main`; if violated, report, move diff to a non-main worktree/branch, then restore root workspace clean.
+Across repos, prefer repo-root `.worktrees/`; avoid changing main checkouts unless explicitly requested.
 §
 User cares strongly about code structure and file paths, including tests: place test files on paths mirroring the source file paths they cover.
 §
@@ -172,6 +172,8 @@ In corp-web-japan resource-list refactors, the user wants page.tsx to keep route
 §
 For repo-local workspace cleanup, the user wants branches/worktrees not connected to an open PR treated as stale candidates by default, but local changes must be validated against the latest main branch HEAD first; if a branch has multiple commits, judge meaningfulness after squashing conceptually to the net diff vs latest main, and if the branch is behind, use rebase onto latest main as a quick signal of whether the branch history is stale.
 §
+In corp-web-japan resource-list route work, the user wants each page.tsx to keep direct route-authored hero markup (`ResourceListHeroSection`, `ResourceListHeroTitle`, `ResourceListHeroDescription`) and CTA sections; only the repeated sidebar structure may be extracted into a shared concrete component.
+§
 For stakeholder-facing webpage intro/description copy, never mention 'MDX'. Treat 'MDX' as an internal file-format term that should not appear in customer-facing explanatory text.
 §
 In corp-web-japan PR follow-up scope, removing demo /t entrypoints does not imply removing the general Preview Toggle UI or its API route. Keep that scope narrow unless the user explicitly asks to remove the global preview toggle.
@@ -182,14 +184,12 @@ In corp-web-japan copy/content follow-up work, if the user asks to correct a mis
 §
 In corp-web-japan publication/routing audits, the user wants review focus on actual missing redirects and wrong redirect targets on the latest origin/main baseline, not on 'shrink/removal candidates.' Evidence should be prioritized from latest main code, route implementation, and stage/live behavior.
 §
-In corp-web-japan, ask and confirm before implementing route renames/canonical-route decisions. When preview /t/* routes are promoted/replaced, do not keep /t/* endpoints or redirects unless explicitly requested.
+In corp-web-japan, when preview /t/* routes are promoted or replaced, the user does not want the /t/* endpoints kept at all and does not want redirect compatibility left behind, unless they explicitly ask for a specific /t/* path to remain. Default policy: remove /t/* route files entirely, not redirect them.
 §
-For visual/layout bugs, the user expects direct verification against exact live/Preview URLs before claiming a fix, strongly prefers one-pass thorough fixes over iterative trial-and-error, and may request explicit validation commits pushed to the existing PR so they can inspect visual tradeoffs in Preview.
+For visual/layout bugs, the user expects direct verification against the exact provided live page and Preview Deployment URL before claiming a fix, and strongly prefers one-pass thorough fixes over iterative trial-and-error that makes them re-test repeatedly.
 §
 For querypie.com/ja page migrations in corp-web-japan, the user wants the existing page copied as-is without invented preview explanation text, rewritten title/description copy, or new CTA sections unless explicitly requested.
 §
 If browser interaction is needed while another agent is using the browser, the user wants new tabs/pages opened instead of reusing or disturbing existing browser tabs/windows.
 §
 For corp-web-japan and similar repo work, any reusable migration/workflow skill should be provided as a repo-local skill under .agents/skills/, not only as a built-in/global skill.
-§
-For GitHub living issues, user expects remaining-work items to be concrete and explainable, with explicit scope boundaries: what changes, what stays unchanged, and why it matters.


### PR DESCRIPTION
## 요약
- 최신 local preference / environment 해석을 MEMORY.md와 USER.md에 반영했습니다
- Hermes 설정 파일 자체는 현재 `origin/main`과 동일해서 이번 PR의 net diff에는 포함되지 않습니다

## 포함 파일
- `.hermes/memories/MEMORY.md`
- `.hermes/memories/USER.md`
