### PR TITLE
docs: 로컬 skill guidance 보존

### DIFF
--- a/.hermes/memories/MEMORY.md
+++ b/.hermes/memories/MEMORY.md
@@ -11,3 +11,5 @@ In the current skills-jk environment, skill_manage(action='patch') for github-pr
 This user's workstation has Python3 + available subprocess scripting module for bulk git operations in large PR-heavy repos.
 §
 On this user's macOS environment, oh-my-codex (OMX) v0.18.5 is installed globally via nvm npm at `/Users/jk/.nvm/versions/node/v22.10.0/bin/omx`; `omx setup --merge-agents` configured user-scope Codex files under `/Users/jk/.codex`, preserving existing user-managed MCP servers. Codex CLI is Homebrew-owned at `/opt/homebrew/bin/codex` and authenticated via ChatGPT.
+§
+Local Codex on this workstation is configured to discover skills-jk via symlinks: `~/.agents/skills/skills-jk-hermes -> /Users/jk/workspace/skills-jk/.hermes/skills` and `~/.agents/skills/skills-jk -> /Users/jk/workspace/skills-jk/skills`; verify with `codex debug prompt-input 'noop'` in a new Codex session.

--- a/.hermes/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/.hermes/skills/autonomous-ai-agents/codex/SKILL.md
@@ -64,6 +64,8 @@ Codex CLI config is commonly at `~/.codex/config.toml`. For Codex CLI 0.130.0 mo
 
 For Codex CLI 0.130.0 skill discovery paths and how to expose external local skill trees such as `~/workspace/skills-jk/skills` and Hermes `.hermes/skills`, see `references/codex-cli-0.130-skill-discovery.md`. Key point: Codex discovers `$HOME/.agents/skills` and follows symlinked directories there; do not invent unsupported `skills.paths` config keys.
 
+For the currently verified local setup pattern on Codex CLI 0.133.0, see `references/codex-cli-local-skill-symlink-discovery.md`. Use `~/.agents/skills` symlinks for external skill libraries, restart Codex after changing symlinks, and verify with `codex debug prompt-input 'noop'` rather than editing `~/.codex/config.toml` with unsupported path keys.
+
 For Codex CLI 0.130.0 custom OpenAI-compatible Responses providers, see `references/codex-cli-0.130-custom-responses-provider.md`. Key point: Codex uses `model_provider` plus `[model_providers.<id>]` TOML, not Hermes `providers:` YAML; always verify with a temporary `CODEX_HOME` before changing `~/.codex/config.toml`, and if `codex exec` says `Warning: no last agent message`, inspect the provider's streaming Responses events for missing finalization events.
 
 For Codex CLI 0.130.0 `/goal`, see `references/codex-cli-0.130-goals-feature.md`. Key point: `/goal` is the experimental `goals` feature flag, not a plugin-list entry; it exposes `get_goal`, `create_goal`, and completion-only `update_goal` tools plus continuation prompts. When recreating it in Hermes, use a `name: goal` skill plus an explicit state script unless Hermes core runtime hooks are being changed.

--- a/.hermes/skills/autonomous-ai-agents/codex/references/codex-cli-local-skill-symlink-discovery.md
+++ b/.hermes/skills/autonomous-ai-agents/codex/references/codex-cli-local-skill-symlink-discovery.md
@@ -1,0 +1,64 @@
+# Codex CLI local skill discovery via `~/.agents/skills` symlinks
+
+Use this when the user wants local Codex to reference an external skill library such as `skills-jk/.hermes/skills` without copying files or inventing unsupported Codex config keys.
+
+## Verified pattern
+
+Codex CLI 0.133.0 discovers skill directories exposed through symlinks under:
+
+```bash
+$HOME/.agents/skills
+```
+
+For the `skills-jk` repository, the default recommended setup is:
+
+```bash
+mkdir -p ~/.agents/skills
+
+ln -sfn "$HOME/workspace/skills-jk/.hermes/skills" \
+  "$HOME/.agents/skills/skills-jk-hermes"
+
+ln -sfn "$HOME/workspace/skills-jk/skills" \
+  "$HOME/.agents/skills/skills-jk"
+```
+
+After creating or changing symlinks, restart Codex. Skill discovery happens when a Codex session starts; already-running sessions may not pick up the change.
+
+## Verification
+
+Use `codex debug prompt-input` and check that expected skill paths or names appear in the prompt input:
+
+```bash
+codex debug prompt-input 'noop' > /tmp/codex-prompt.json
+
+python3 - <<'PY'
+import json
+from pathlib import Path
+
+data = json.loads(Path('/tmp/codex-prompt.json').read_text())
+text = '\n'.join(
+    c.get('text', '')
+    for item in data
+    for c in item.get('content', [])
+    if c.get('type') == 'input_text'
+)
+
+for needle in [
+    '/Users/jk/workspace/skills-jk/.hermes/skills',
+    '/Users/jk/workspace/skills-jk/skills',
+    'hermes-agent',
+    'corp-web-app-pack',
+    'github-pr-workflow',
+]:
+    print(needle, '=>', needle in text)
+PY
+```
+
+Expected result after setup: the two paths and representative skill names print `True`.
+
+## Pitfalls
+
+- Do not add unsupported keys such as `skills.paths` or `[skills] paths = [...]` to `~/.codex/config.toml`. The `[skills]` section is for controlling discovered skills, not registering arbitrary discovery roots.
+- The symlink label itself (for example `skills-jk-hermes`) may not appear in the prompt input. Check for target paths or actual skill names instead.
+- Exposing `.hermes/skill-packs` directly is optional. Prefer `.hermes/skills` as the default because it contains active entrypoint skills such as repo pack skills; add `.hermes/skill-packs` only when future Codex sessions need direct access to detailed pack internals.
+- Tool invocations in `skills-jk` can generate local Hermes runtime residue such as `.hermes/kanban.db-wal` and `.hermes/kanban.db-shm`; keep those ignored locally rather than treating them as skill changes.

--- a/.hermes/skills/software-development/corp-web-app-pack/SKILL.md
+++ b/.hermes/skills/software-development/corp-web-app-pack/SKILL.md
@@ -42,6 +42,7 @@ Then read only the specific `SKILL.md` files referenced by the index that match 
 - `references/introduction-deck-mdx-gating.md` — proven pattern for fixing gated introduction-deck MDX detail pages by splitting at `<GatingCut />`, rendering the post-cut content behind `GatingFormWrapper`, and using a temporary root `node_modules` symlink for fast fresh-worktree verification when appropriate.
 - `references/publication-author-data-location.md` — author/profile data placement and PR follow-up pattern for blog/whitepaper detail author cards.
 - `references/author-profile-image-validation.md` — investigation and hardening pattern for broken publication author profile images: resolve MDX `author` through locale YAML, verify the referenced `public/crew/*` asset and deployed raw/`/_next/image` URLs, and compare against corp-web-japan's `src/content/authors/ja.yaml` + `public/crew/*` + validation-test pattern.
+- `references/blog-mdx-translation-coverage.md` — workflow for finding and filling missing blog MDX locale files from historical corp-web-contents inventories, preserving hidden redirect contracts, protecting MDX/HTML syntax during translation, and verifying EN/KO/JA coverage parity.
 
 ## Common Pitfalls
 
@@ -53,6 +54,7 @@ Then read only the specific `SKILL.md` files referenced by the index that match 
 6. For gated introduction-deck MDX, do not render the entire body with `GatingCut: () => null`; split at the marker first so the post-cut content and download CTA stay behind the form.
 7. Treat localized author/profile JSON as publication content, not utility implementation. In corp-web-app it belongs under `src/content/authors/{en,ja,ko}.json`; utilities such as `composeAuthors` should import from that content path rather than keeping data under `src/utils/**/data`.
 8. During PR follow-up on resource/publication work, expect latest `main` to have renamed `src/lib/repo-content/**` to `src/lib/resources/**`. On rebase conflicts, preserve the latest-main `src/lib/resources` import paths and reapply only the PR's scoped author/rendering changes.
+9. For blog MDX missing-locale recovery, do not invent translations when the user asked for source recovery only. First exhaust historical corp-web-contents inventories and sibling/canonical publication records; only directly translate unfound content if the user explicitly changes scope to permit direct translation.
 
 ## Verification Checklist
 

--- a/.hermes/skills/software-development/corp-web-app-pack/references/blog-mdx-translation-coverage.md
+++ b/.hermes/skills/software-development/corp-web-app-pack/references/blog-mdx-translation-coverage.md
@@ -1,0 +1,50 @@
+# Blog MDX translation coverage recovery
+
+Use this reference for `corp-web-app` tasks that ask to find and fill missing blog MDX locale files, especially when using historical `corp-web-contents` material.
+
+## Proven workflow
+
+1. Work from latest `origin/main` in a separate worktree/branch; do not edit the root checkout.
+2. Load repo-local publication skills first when available:
+   - `.agents/skills/mdx-publication-operations/SKILL.md`
+   - `.agents/skills/blog-posting/SKILL.md`
+3. Build a locale coverage scan over `src/content/blog/*.mdx` grouped by numeric blog id and expected locales (`en`, `ko`, `ja`). Report the exact missing id/locale pairs before editing.
+4. Search historical sources before translating:
+   - `docs/inventories/corp-web-contents-document-locale-inventory.md`
+   - historical `corp-web-contents` MDX file paths from git history
+   - related canonical content families such as `src/content/news/**` when the blog record is a hidden redirect/shadow record.
+5. If the user says not to translate manually, leave unfound locale content unfixed and report it as not found. If the user explicitly asks for direct translation after source recovery fails, add translations but keep them scoped to the missing locale files.
+6. Preserve frontmatter contract and route-aligned assets:
+   - keep `id`, `slug`, `title`, `description`, `date`, `heroImageSrc`, `relatedIds`, and `keywords` shape aligned with sibling locales.
+   - use `public/blog/<id>/...` asset paths; do not introduce legacy `public/blog/<filename>` paths.
+   - for shadow redirect records, preserve `hidden: true` and `redirectUrl` exactly so they stay out of public lists and redirect to the canonical record.
+7. When generating or normalizing translated MDX, protect Markdown links, HTML/JSX tags, and inline hrefs with placeholders before machine-assisted translation. Reinsert placeholders after translation and scan for malformed `<a ...>`, `href=`, or broken Markdown link syntax.
+8. Update the publication/resource migration tests to reflect the new record count and locale coverage. On newer `main`, expect the blog migration tests under `src/lib/resources/__tests__/blog-migration.test.ts` rather than the older `src/lib/repo-content/__tests__/...` path.
+
+## Verification pattern
+
+Run the lightest focused checks:
+
+```bash
+npx vitest run src/lib/resources/__tests__/blog-migration.test.ts
+git diff --check
+```
+
+Also run a source scan that verifies:
+
+- every blog id has all expected locales.
+- YAML frontmatter parses.
+- locale counts match expected EN/KO/JA parity.
+- no malformed anchor/href candidates were introduced.
+- no legacy `public/blog/<filename>` asset paths exist.
+
+## PR notes
+
+In the PR body, list:
+
+- exact missing locale pairs filled.
+- which entries were historical-source recovery versus direct translation, if both occurred.
+- any hidden redirect contracts preserved.
+- focused verification command results.
+
+Do not close or auto-close related issues from the PR body unless the user explicitly asks.


### PR DESCRIPTION
## 요약
- 로컬 Codex가 skills-jk 스킬을 `~/.agents/skills` symlink로 discovery하는 검증된 절차를 codex skill reference로 보존했습니다.
- 현재 워크스테이션의 Codex symlink 설정 사실을 repo-local memory에 기록했습니다.
- corp-web-app 블로그 MDX locale coverage 복구 workflow를 pack reference로 보존했습니다.

## 검증
- 로컬 변경사항을 최신 `origin/main` 기반 worktree로 3-way 적용했습니다.
- 문서/스킬 guidance 변경만 포함되도록 diff를 확인했습니다.
- 별도 로컬 build/test는 요청 선호에 따라 실행하지 않았습니다.
