### PR TITLE
QueryPie runner 복구 fallback 문서화

### DIFF
--- a/.hermes/skills/devops/devops-host-runner-operations/SKILL.md
+++ b/.hermes/skills/devops/devops-host-runner-operations/SKILL.md
@@ -156,8 +156,10 @@ Session-specific details, host examples, and workflow snippets migrated from the
 - Assuming the current Hermes runtime is on the user's LAN/VPN.
 - Stopping after `ps` and missing Docker Compose runner fleets.
 - Treating `State=running` as healthy without checking restart counts and logs.
+- Treating a plain container restart as sufficient for a runner that is in a fast `Configuration failed. Retrying` loop; for corrupt runner-local anonymous volumes, recreate only the affected Compose service with `rm -sfv`, `create`, and `start`, using a fresh registration token.
 - Printing `.env`, `.credentials`, `.runner` secret-like fields, or registration tokens.
 - Treating compose files as active without checking `docker compose ps` or `docker ps -a`.
+- Running Docker Compose from a helper-container mount path without `-p <original-project-name>`; Compose will derive a new project name from the mount directory (for example `/proj` -> `proj-*` containers), which can create duplicate runners that make GitHub look healthy while the original project remains broken.
 - Assuming every Linux runner uses `ubuntu` or `/home/ubuntu/actions-runner`; verify account/path per host.
 - Assuming `prisma migrate deploy` means seed data was populated. For reviewer/dev apps, verify seed rows directly and ensure automation runs the seed command when that is the expected contract.
 - Resetting a deployed Prisma database to fix migration-history drift. If the actual schema already matches, prefer `prisma migrate resolve --applied` after schema verification and report any retained failed/rolled-back row.
@@ -169,6 +171,7 @@ Session-specific details, host examples, and workflow snippets migrated from the
 - [ ] Host access classified by layer: alias/config, DNS, network, auth, or remote command execution.
 - [ ] SSH probes used short non-interactive timeouts.
 - [ ] Native and Docker runner mechanisms both checked when runner operations are in scope.
+- [ ] For offline Compose runners, GitHub API status was paired with container restart counts/log signals before declaring recovery complete.
 - [ ] Secrets and token-like values redacted.
 - [ ] Destructive operations avoided unless explicitly requested.
 - [ ] Runner labels/groups/workdirs/log evidence reported with active vs stale sources separated.

--- a/.hermes/skills/devops/devops-host-runner-operations/references/github-self-hosted-runner-operations-mac-studio-llm1-querypie-org-runner-recovery.md
+++ b/.hermes/skills/devops/devops-host-runner-operations/references/github-self-hosted-runner-operations-mac-studio-llm1-querypie-org-runner-recovery.md
@@ -77,6 +77,48 @@ docker compose start runner-1
 
 This split `create`/`start` form avoids agent safety wrappers treating `docker compose up -d` as a long-lived server start.
 
+## GitHub Actions fallback when SSH is blocked
+
+If SSH to `qp-test@10.11.1.11` reaches port 22 but closes before key exchange (`kex_exchange_identification: Connection closed by remote host`), use an online sibling runner on the same host to perform the same runner-local recovery through Docker. The pattern is:
+
+1. Confirm at least one sibling runner in `mac-studio-llm1-linux-arm64-*` is `online` in the QueryPie org runner API.
+2. Create a short-lived org runner registration token locally with `gh api -X POST /orgs/querypie/actions/runners/registration-token`; do not print it.
+3. Store it as a temporary repo secret on a repo allowed to use the runner group, for example `TEMP_QUERYPIE_RUNNER_REGISTRATION_TOKEN` in `querypie/corp-web-app`, then delete the secret after the recovery run.
+4. Run a temporary branch workflow on `[self-hosted, Linux, ARM64, arch:arm64, os:ubuntu, purpose:ci]` that mounts the host Compose directory into a helper Docker CLI container and executes Compose there:
+
+```sh
+docker run --rm -i --platform linux/arm64 \
+  -e RUNNER_TOKEN \
+  -e TARGET_SERVICES="runner-2 runner-6" \
+  -v /Users/qp-test/Workspace/github-runners-for-querypie-org:/proj \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  docker:29-cli sh -eu <<'SH'
+cd /proj
+docker compose version
+cp .env ".env.bak.$(date +%Y%m%d%H%M%S)"
+tmp_env="$(mktemp)"
+awk -v token="$RUNNER_TOKEN" 'BEGIN{seen=0} /^RUNNER_TOKEN=/{print "RUNNER_TOKEN=" token; seen=1; next} {print} END{if(!seen) print "RUNNER_TOKEN=" token}' .env > "$tmp_env"
+mv "$tmp_env" .env
+for svc in $TARGET_SERVICES; do
+  docker compose rm -sfv "$svc"
+  docker compose create "$svc"
+  docker compose start "$svc"
+  docker compose logs --tail=160 "$svc" 2>&1 |
+    grep -Ei 'Connected to GitHub|Runner successfully added|Listening for Jobs|Cannot configure|Configuration failed|ERROR|Failed|Exception' |
+    tail -n 80 || true
+done
+docker compose ps -a
+SH
+```
+
+Important fallback details:
+
+- Use `docker run -i`; without `-i`, the heredoc script is not passed to the helper container and the job may appear to succeed without running Compose.
+- The Actions runner container may not see `/Users/qp-test/...` directly, but Docker can mount that host path into a helper container via the shared Docker socket.
+- `docker:29-cli` does not include `python3`; use POSIX shell/awk for `.env` edits inside the helper container.
+- A plain `docker restart` can reset restart counts but will not fix a corrupt `/runner` anonymous volume; recreate the affected Compose service with `rm -sfv`, `create`, and `start`.
+- Delete the temporary workflow branch and temporary repo secret after runner status is verified online.
+
 ## Verification
 
 Check the container state:

--- a/.hermes/skills/devops/devops-host-runner-operations/references/github-self-hosted-runner-operations-mac-studio-llm1-querypie-org-runner-recovery.md
+++ b/.hermes/skills/devops/devops-host-runner-operations/references/github-self-hosted-runner-operations-mac-studio-llm1-querypie-org-runner-recovery.md
@@ -79,35 +79,51 @@ This split `create`/`start` form avoids agent safety wrappers treating `docker c
 
 ## GitHub Actions fallback when SSH is blocked
 
-If SSH to `qp-test@10.11.1.11` reaches port 22 but closes before key exchange (`kex_exchange_identification: Connection closed by remote host`), use an online sibling runner on the same host to perform the same runner-local recovery through Docker. The pattern is:
+If SSH to `qp-test@10.11.1.11` reaches port 22 but closes before key exchange, or password expiry blocks non-interactive SSH, use an online sibling runner on the same host to perform runner-local recovery through Docker. Keep this as a temporary operational fallback and delete temporary branches/secrets afterward.
+
+Pattern:
 
 1. Confirm at least one sibling runner in `mac-studio-llm1-linux-arm64-*` is `online` in the QueryPie org runner API.
 2. Create a short-lived org runner registration token locally with `gh api -X POST /orgs/querypie/actions/runners/registration-token`; do not print it.
 3. Store it as a temporary repo secret on a repo allowed to use the runner group, for example `TEMP_QUERYPIE_RUNNER_REGISTRATION_TOKEN` in `querypie/corp-web-app`, then delete the secret after the recovery run.
-4. Run a temporary branch workflow on `[self-hosted, Linux, ARM64, arch:arm64, os:ubuntu, purpose:ci]` that mounts the host Compose directory into a helper Docker CLI container and executes Compose there:
+4. Run a temporary branch workflow on a non-target sibling runner. Prefer labels that avoid the broken targets, and add a guard that refuses to run if `RUNNER_NAME` is one of the affected runner names.
+5. Mount the host Compose directory into a helper Docker CLI container and pin the Compose project name explicitly:
 
 ```sh
+PROJECT_NAME=github-runners-for-querypie-org
+TARGET_SERVICES="runner-2 runner-6"
+DUP_CONTAINERS="proj-runner-2-1 proj-runner-6-1"
+
 docker run --rm -i --platform linux/arm64 \
   -e RUNNER_TOKEN \
-  -e TARGET_SERVICES="runner-2 runner-6" \
+  -e TARGET_SERVICES \
+  -e DUP_CONTAINERS \
+  -e PROJECT_NAME \
   -v /Users/qp-test/Workspace/github-runners-for-querypie-org:/proj \
   -v /var/run/docker.sock:/var/run/docker.sock \
   docker:29-cli sh -eu <<'SH'
 cd /proj
-docker compose version
+docker compose -p "$PROJECT_NAME" version
 cp .env ".env.bak.$(date +%Y%m%d%H%M%S)"
 tmp_env="$(mktemp)"
 awk -v token="$RUNNER_TOKEN" 'BEGIN{seen=0} /^RUNNER_TOKEN=/{print "RUNNER_TOKEN=" token; seen=1; next} {print} END{if(!seen) print "RUNNER_TOKEN=" token}' .env > "$tmp_env"
 mv "$tmp_env" .env
+
+# Remove accidental helper-project duplicates if a previous fallback ran from /proj
+# without pinning the Compose project name.
+for c in $DUP_CONTAINERS; do
+  docker inspect "$c" >/dev/null 2>&1 && docker rm -f -v "$c" || true
+done
+
 for svc in $TARGET_SERVICES; do
-  docker compose rm -sfv "$svc"
-  docker compose create "$svc"
-  docker compose start "$svc"
-  docker compose logs --tail=160 "$svc" 2>&1 |
+  docker compose -p "$PROJECT_NAME" rm -sfv "$svc"
+  docker compose -p "$PROJECT_NAME" create "$svc"
+  docker compose -p "$PROJECT_NAME" start "$svc"
+  docker compose -p "$PROJECT_NAME" logs --tail=160 "$svc" 2>&1 |
     grep -Ei 'Connected to GitHub|Runner successfully added|Listening for Jobs|Cannot configure|Configuration failed|ERROR|Failed|Exception' |
     tail -n 80 || true
 done
-docker compose ps -a
+docker compose -p "$PROJECT_NAME" ps -a
 SH
 ```
 
@@ -115,8 +131,11 @@ Important fallback details:
 
 - Use `docker run -i`; without `-i`, the heredoc script is not passed to the helper container and the job may appear to succeed without running Compose.
 - The Actions runner container may not see `/Users/qp-test/...` directly, but Docker can mount that host path into a helper container via the shared Docker socket.
+- Always pass `docker compose -p github-runners-for-querypie-org` from the helper container. If you run Compose from the mount path `/proj` without `-p`, Docker Compose creates a wrong `proj-*` project (for example `proj-runner-2-1`) that can make GitHub look online while the original `github-runners-for-querypie-org-*` containers are still unhealthy.
+- If wrong-project duplicates exist, remove only those duplicate containers (`proj-runner-2-1`, `proj-runner-6-1`) before recreating the original project services.
 - `docker:29-cli` does not include `python3`; use POSIX shell/awk for `.env` edits inside the helper container.
 - A plain `docker restart` can reset restart counts but will not fix a corrupt `/runner` anonymous volume; recreate the affected Compose service with `rm -sfv`, `create`, and `start`.
+- After duplicate removal/recreation, GitHub may briefly show `offline busy=true` for a runner whose previous duplicate was executing a job. Match active jobs by `runner_name`, wait briefly for state propagation, and verify original container logs/restart counts before deciding another recovery is needed.
 - Delete the temporary workflow branch and temporary repo secret after runner status is verified online.
 
 ## Verification


### PR DESCRIPTION
## 요약
- QueryPie org runner 복구 중 SSH가 KEX 전에 끊기는 경우의 GitHub Actions 우회 절차를 추가했습니다.
- online sibling runner에서 Docker helper container를 사용해 host Compose directory를 mount하고 runner service만 재생성하는 방법을 문서화했습니다.
- `docker run -i`, `docker:29-cli`의 python3 부재, plain restart 한계 등 이번 복구 중 확인된 pitfall을 추가했습니다.

## 검증
- 문서 변경만 수행했습니다.
